### PR TITLE
fix(security): verify Slack request signatures on /slack/events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,19 +90,21 @@ Request → AWS Lambda → Middleware Stack → Route Matcher → Controller →
 ```
 
 **Middleware Stack** (in order, defined in `src/index.js`):
-1. `authWrapper` - Authentication (JWT, IMS, API Keys, Scoped API Keys)
-2. `logWrapper` - Structured logging
-3. `dataAccess` - Data access layer (`@adobe/spacecat-shared-data-access`)
-4. `bodyData` - Request body parsing
-5. `multipartFormData` - File upload handling
-6. `enrichPathInfo` - Path parameter extraction
-7. `sqs` - AWS SQS client
-8. `s3ClientWrapper` - AWS S3 client
-9. `imsClientWrapper` - Adobe IMS client
-10. `elevatedSlackClientWrapper` - Slack client
-11. `secrets` - AWS Secrets Manager
-12. `helixStatus` - Health checks
-13. `facsWrapper` - FACS/ReBAC customer-authorization enforcement for FACS-governed routes (innermost wrapper — attached first in the `wrap(...).with(...)` chain, so it runs last, immediately before the controller; configured with `routeFacsCapabilities` + `secondaryResolvers`; see Access Control → FACS-native authorization)
+1. `s2sAuthWrapper` - S2S JWT bearer tokens; passes non-S2S through to `authWrapper`
+2. `authWrapper` - Authentication (JWT, IMS, API Keys, Scoped API Keys)
+3. `logWrapper` - Structured logging
+4. `dataAccess` - Data access layer (`@adobe/spacecat-shared-data-access`)
+5. `bodyData` - Request body parsing
+6. `multipartFormData` - File upload handling
+7. `slackSignatureWrapper` - Slack request-signature verification for `/slack/events` (VULN-39365). Declared immediately before `enrichPathInfo` so it *runs* immediately after it (last `.with()` = outermost = runs first), which puts it after `pathInfo` is populated but before the body is consumed; it reads the body via `request.clone()`
+8. `enrichPathInfo` - Path parameter extraction
+9. `sqs` - AWS SQS client
+10. `s3ClientWrapper` - AWS S3 client
+11. `imsClientWrapper` - Adobe IMS client
+12. `elevatedSlackClientWrapper` - Slack client
+13. `secrets` - AWS Secrets Manager
+14. `helixStatus` - Health checks
+15. `facsWrapper` - FACS/ReBAC customer-authorization enforcement for FACS-governed routes (innermost wrapper — attached first in the `wrap(...).with(...)` chain, so it runs last, immediately before the controller; configured with `routeFacsCapabilities` + `secondaryResolvers`; see Access Control → FACS-native authorization)
 
 All dependencies are injected into `context` and available throughout the request lifecycle.
 

--- a/src/index.js
+++ b/src/index.js
@@ -493,10 +493,16 @@ const wrappedMain = wrap(run)
   })
   .with(authWrapper, {
     authHandlers: AUTH_HANDLERS,
-    // Declare the bypass explicitly rather than inheriting the shared library's default, so
-    // this service owns the list of routes it leaves unauthenticated. POST /slack/events is
-    // authenticated instead by slackSignatureWrapper above, which runs before this wrapper.
-    // Harmless no-op against shared versions predating the option (they use the same default).
+    // Declare the route-based anonymous bypass explicitly rather than inheriting the shared
+    // library's default, so this service owns the list of routes it leaves unauthenticated.
+    // POST /slack/events is authenticated instead by slackSignatureWrapper above, which runs
+    // before this wrapper.
+    //
+    // Inert on the currently pinned @adobe/spacecat-shared-http-utils (which does not read the
+    // option and applies its own default); it takes effect once the version carrying
+    // `anonymousEndpoints` is picked up. Declaring it now is forward-safe, not a behaviour
+    // change: the option replaces only the exact-match route list -- the unconditional OPTIONS
+    // and `POST /hooks/site-detection/*` bypasses are separate clauses it does not touch.
     anonymousEndpoints: ['POST /slack/events'],
   })
   .with(s2sAuthWrapper, { routeCapabilities: routeRequiredCapabilities });

--- a/src/index.js
+++ b/src/index.js
@@ -491,7 +491,14 @@ const wrappedMain = wrap(run)
     routeCapabilities: routeRequiredCapabilities,
     internalRoutes: INTERNAL_ROUTES,
   })
-  .with(authWrapper, { authHandlers: AUTH_HANDLERS })
+  .with(authWrapper, {
+    authHandlers: AUTH_HANDLERS,
+    // Declare the bypass explicitly rather than inheriting the shared library's default, so
+    // this service owns the list of routes it leaves unauthenticated. POST /slack/events is
+    // authenticated instead by slackSignatureWrapper above, which runs before this wrapper.
+    // Harmless no-op against shared versions predating the option (they use the same default).
+    anonymousEndpoints: ['POST /slack/events'],
+  })
   .with(s2sAuthWrapper, { routeCapabilities: routeRequiredCapabilities });
 
 export const main = wrappedMain

--- a/src/index.js
+++ b/src/index.js
@@ -122,6 +122,7 @@ import ElementsController from './controllers/elements.js';
 import ProxyController from './controllers/proxy.js';
 import OnboardingController from './controllers/onboarding.js';
 import GitHubWebhookHmacHandler from './support/github-webhook-hmac-handler.js';
+import { slackSignatureWrapper } from './support/slack/signature-wrapper.js';
 import AsoOverlayKeyHandler from './support/aso-overlay-key-handler.js';
 import ApiKeyImsHandler from './support/api-key-ims-handler.js';
 import RouteScopedLegacyApiKeyHandler from './support/route-scoped-legacy-api-key-handler.js';
@@ -500,6 +501,11 @@ export const main = wrappedMain
   .with(dataAccess)
   .with(bodyData)
   .with(multipartFormData)
+  // Runs immediately after enrichPathInfo (so context.pathInfo.headers is populated) and
+  // before multipartFormData/bodyData (so the request body is still unread). Verifies the
+  // Slack request signature on /slack/events, which authWrapper treats as an anonymous
+  // endpoint and which bypasses Bolt's own receiver-level check (VULN-39365).
+  .with(slackSignatureWrapper)
   .with(enrichPathInfo)
   .with(sqs)
   .with(s3ClientWrapper)

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -196,8 +196,7 @@ const routeFacsCapabilities = {
     'POST /hooks/site-detection/cdn/:hookSecret', // hookSecret in path
     'POST /hooks/site-detection/rum/:hookSecret', // hookSecret in path
     'POST /webhooks/github', // HMAC-signed webhook
-    'GET /slack/events', // Slack signature verification
-    'POST /slack/events', // Slack signature verification
+    'POST /slack/events', // Slack signature verification (slackSignatureWrapper)
     'POST /slack/channels/invite-by-user-id', // Slack-internal
     'GET /trigger', // internal scheduler
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -503,7 +503,9 @@ export default function getRouteHandlers(
     'GET /sites/:siteId/top-pages/:source/:geo': sitesController.getTopPages,
     'POST /sites/:siteId/graph': sitesController.getGraph,
 
-    'GET /slack/events': slackController.handleEvent,
+    // NOTE: there is deliberately no `GET /slack/events`. Slack only ever POSTs events and
+    // interactive payloads, and a GET carries no body to sign, so it could never satisfy the
+    // signature check in slackSignatureWrapper (VULN-39365).
     'POST /slack/events': slackController.handleEvent,
     'POST /slack/channels/invite-by-user-id': slackController.inviteUserToChannel,
     'GET /trigger': triggerHandler,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -64,8 +64,8 @@ export const INTERNAL_ROUTES = [
   'POST /sites/:siteId/geo-experiments/:geoExperimentId/trigger-impact-measurement',
   'POST /sites/:siteId/geo-experiments/:geoExperimentId/validate',
 
-  // Slack - event subscriptions and commands use Slack's signature verification
-  'GET /slack/events',
+  // Slack - event subscriptions and commands are authenticated by the Slack request
+  // signature (slackSignatureWrapper), not by a SpaceCat capability.
   'POST /slack/events',
   'POST /slack/channels/invite-by-user-id',
 

--- a/src/support/access-control-util.js
+++ b/src/support/access-control-util.js
@@ -27,7 +27,8 @@ import { listResourceIdsWithCapability } from './state-access-mapping-utils.js';
 import routeFacsCapabilities from '../routes/facs-capabilities.js';
 
 const ANONYMOUS_ENDPOINTS = [
-  /^GET \/slack\/events$/,
+  // NOTE: no `GET /slack/events` — the route was removed (VULN-39365). Slack only ever POSTs,
+  // and a GET carries no body to sign, so it could never be signature-verified.
   /^POST \/slack\/events$/,
   /^POST \/hooks\/site-detection.+/,
 ];

--- a/src/support/slack/commands/toggle-site-audit.js
+++ b/src/support/slack/commands/toggle-site-audit.js
@@ -19,6 +19,7 @@ import { Readable } from 'stream';
 import { parse } from 'csv';
 import BaseCommand from './base.js';
 import { extractURLFromSlackInput, loadProfileConfig } from '../../../utils/slack/base.js';
+import { isSlackFileUrl } from '../../../utils/slack/file-url.js';
 
 const PHRASE = 'audit';
 const SUCCESS_MESSAGE_PREFIX = ':white_check_mark: ';
@@ -231,6 +232,13 @@ export default (context) => {
       }
 
       const file = files[0];
+
+      // Only ever send the bot token to a Slack-owned host (VULN-39365). Do not echo the
+      // rejected URL back into Slack -- it is attacker-controlled.
+      if (!isSlackFileUrl(file.url_private)) {
+        await say(`${ERROR_MESSAGE_PREFIX}Refusing to download file: URL is not a Slack-hosted https URL.`);
+        return;
+      }
 
       const response = await fetch(file.url_private, {
         headers: {

--- a/src/support/slack/signature-wrapper.js
+++ b/src/support/slack/signature-wrapper.js
@@ -12,6 +12,7 @@
 
 import crypto from 'crypto';
 import { Response } from '@adobe/fetch';
+import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 import { hasText } from '@adobe/spacecat-shared-utils';
 
 /**
@@ -58,6 +59,13 @@ const TIMESTAMP_HEADER = 'x-slack-request-timestamp';
 // authenticated by RouteScopedLegacyApiKeyHandler, not a request signed by Slack.
 const SLACK_SIGNED_PATHS = new Set(['/slack/events', 'slack/events']);
 
+// CORS preflight is answered by `run()` in src/index.js with a 204 before any route handler is
+// reached, and carries no body to sign. Excluding it keeps that behaviour intact rather than
+// turning every preflight into a 401. Every other method on the guarded suffix is verified --
+// deliberately wider than the single `POST` the router exposes today, so that re-adding a route
+// on this path cannot silently create an unverified entry point.
+const UNVERIFIED_METHODS = new Set(['OPTIONS']);
+
 /**
  * Constant-time comparison of the received signature against the expected one.
  * Both operands are known to be 67 ASCII chars ("v0=" + 64 hex) because the caller has already
@@ -75,9 +83,15 @@ function signaturesMatch(received, expected) {
 /**
  * Computes the Slack v0 signature for a raw body.
  *
+ * The HMAC is taken over the UTF-8 encoding of the decoded body text. This matches Slack's own
+ * Bolt SDK, which signs `` `${version}:${timestamp}:${body}` `` with `body` as a string
+ * (`@slack/bolt/dist/receivers/verify-request.js`). Slack payloads are UTF-8 JSON or
+ * form-urlencoded, so the decode/encode round-trip is lossless; a body that is not valid UTF-8
+ * is not a legitimate Slack payload and fails closed on the signature comparison.
+ *
  * @param {string} signingSecret - the Slack app signing secret.
  * @param {string} timestamp - the raw `x-slack-request-timestamp` value (unix seconds).
- * @param {string} rawBody - the exact request body bytes, as text.
+ * @param {string} rawBody - the request body, as text.
  * @returns {string} the `v0=<hex>` signature.
  */
 export function computeSlackSignature(signingSecret, timestamp, rawBody) {
@@ -86,14 +100,18 @@ export function computeSlackSignature(signingSecret, timestamp, rawBody) {
 }
 
 /**
- * True when the route is one Slack signs. Tolerates a suffix with or without a leading slash
- * (production sets it with one; some test harnesses do not).
+ * True when the request must carry a valid Slack signature: the route is one Slack signs, and
+ * the method is one that can carry a signed body. Tolerates a suffix with or without a leading
+ * slash (production sets it with one; some test harnesses do not).
  *
  * @param {object} context - the universal context.
  * @returns {boolean}
  */
 function isSlackSignedRoute(context) {
-  return SLACK_SIGNED_PATHS.has(context?.pathInfo?.suffix || '');
+  if (!SLACK_SIGNED_PATHS.has(context?.pathInfo?.suffix || '')) {
+    return false;
+  }
+  return !UNVERIFIED_METHODS.has((context?.pathInfo?.method || '').toUpperCase());
 }
 
 /**
@@ -115,9 +133,25 @@ export function slackSignatureWrapper(fn) {
     const signature = headers[SIGNATURE_HEADER];
     const timestamp = headers[TIMESTAMP_HEADER];
 
-    const unauthorized = (reason) => {
-      // Log the reason, never the signature, body or secret.
-      log.warn(`Slack signature verification failed: ${reason}`);
+    // Emits a 401 plus a diagnosable log line. `reason` is a stable label for alerting;
+    // `detail` carries non-sensitive context so on-call can tell a stripped header (e.g. a CDN
+    // dropping X-Slack-Signature) apart from clock skew or an oversized body WITHOUT having to
+    // reproduce. Never logs the signature, the signing secret or any part of the body.
+    const unauthorized = (reason, detail = {}) => {
+      const fields = {
+        reason,
+        method: context?.pathInfo?.method,
+        suffix: context?.pathInfo?.suffix,
+        traceId: context?.traceId,
+        hasSignatureHeader: hasText(signature),
+        hasTimestampHeader: hasText(timestamp),
+        ...detail,
+      };
+      const rendered = Object.entries(fields)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(' ');
+      log.warn(`Slack signature verification failed: ${rendered}`);
       return new Response('Unauthorized', {
         status: 401,
         headers: { 'x-error': 'slack signature verification failed' },
@@ -128,26 +162,30 @@ export function slackSignatureWrapper(fn) {
     // Fail closed on misconfiguration. An unsigned-but-accepted request is exactly the
     // vulnerability being fixed, so a missing secret must never degrade to "allow".
     if (!hasText(signingSecret)) {
-      return unauthorized('SLACK_SIGNING_SECRET is not configured');
+      return unauthorized('secret_not_configured');
     }
 
     if (!hasText(signature) || !hasText(timestamp)) {
-      return unauthorized('missing signature or timestamp header');
+      // Split so on-call can see WHICH header is absent -- a CDN/proxy stripping one of them
+      // is a realistic production failure and looks nothing like a forged request.
+      return unauthorized('missing_header');
     }
 
     if (!SIGNATURE_PATTERN.test(signature)) {
-      return unauthorized('malformed signature header');
+      return unauthorized('malformed_signature');
     }
 
     // Slack sends unix seconds. Reject anything non-numeric outright rather than letting
     // Number() coerce (e.g. '' -> 0, '  12 ' -> 12) into a value that could pass the window.
     if (!/^\d+$/.test(timestamp)) {
-      return unauthorized('malformed timestamp header');
+      return unauthorized('malformed_timestamp');
     }
 
     const nowSeconds = Math.floor(Date.now() / 1000);
-    if (Math.abs(nowSeconds - Number(timestamp)) > MAX_TIMESTAMP_SKEW_SECONDS) {
-      return unauthorized('timestamp outside the allowed replay window');
+    const skewSeconds = nowSeconds - Number(timestamp);
+    if (Math.abs(skewSeconds) > MAX_TIMESTAMP_SKEW_SECONDS) {
+      // Surfacing the delta distinguishes genuine replay from server clock drift.
+      return unauthorized('stale_timestamp', { skewSeconds, maxSkewSeconds: MAX_TIMESTAMP_SKEW_SECONDS });
     }
 
     // Content-Length is an honest-client hint only (a forger can omit or lie about it); the
@@ -155,7 +193,7 @@ export function slackSignatureWrapper(fn) {
     // a declared-oversized body without buffering it.
     const contentLength = Number(request.headers.get('content-length'));
     if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
-      return unauthorized('request body too large');
+      return unauthorized('body_too_large', { declaredBytes: contentLength, maxBytes: MAX_BODY_BYTES });
     }
 
     let rawBody;
@@ -163,16 +201,19 @@ export function slackSignatureWrapper(fn) {
       // clone() so the body remains readable by multipartFormData / bodyData downstream.
       rawBody = await request.clone().text();
     } catch (e) {
-      return unauthorized(`could not read request body: ${e.message}`);
+      return unauthorized('body_unreadable', { error: cleanupHeaderValue(e.message) });
     }
 
-    if (Buffer.byteLength(rawBody, 'utf8') > MAX_BODY_BYTES) {
-      return unauthorized('request body too large');
+    const bodyBytes = Buffer.byteLength(rawBody, 'utf8');
+    if (bodyBytes > MAX_BODY_BYTES) {
+      return unauthorized('body_too_large', { bodyBytes, maxBytes: MAX_BODY_BYTES });
     }
 
     const expected = computeSlackSignature(signingSecret, timestamp, rawBody);
     if (!signaturesMatch(signature, expected)) {
-      return unauthorized('signature mismatch');
+      // bodyBytes is the single most useful field here: a mismatch with a plausible body size
+      // usually means a body-rewriting proxy, not a forgery.
+      return unauthorized('signature_mismatch', { bodyBytes });
     }
 
     return fn(request, context);

--- a/src/support/slack/signature-wrapper.js
+++ b/src/support/slack/signature-wrapper.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import crypto from 'crypto';
+import { Response } from '@adobe/fetch';
+import { hasText } from '@adobe/spacecat-shared-utils';
+
+/**
+ * Slack request-signature verification (VULN-39365).
+ *
+ * `/slack/events` is listed in ANONYMOUS_ENDPOINTS in spacecat-shared's authWrapper, so the
+ * authentication manager never runs for it. Bolt's own signature check lives in its HTTP
+ * receiver, which this service bypasses by calling `app.processEvent({ body, ack })` on an
+ * already-parsed body — so the configured `signingSecret` was never actually exercised. The
+ * result was an unauthenticated RCE-adjacent surface: forged event and interactive payloads
+ * reached every registered command/action handler, including ones that fetch an
+ * attacker-supplied `url_private` with the bot token attached, and `approveOrg`.
+ *
+ * This wrapper closes that hole at the edge, before any Slack payload is parsed or dispatched.
+ *
+ * Placement (src/index.js): declared immediately BEFORE `enrichPathInfo` in the `.with()` chain.
+ * helix-shared-wrap treats the last `.with()` as outermost, so declaration order bottom-to-top is
+ * execution order — this puts the wrapper directly after `enrichPathInfo` (so `context.pathInfo`
+ * is populated) and before `multipartFormData` / `bodyData` (so the body is still unread).
+ *
+ * The body is read via `request.clone().text()`, never `request.text()`: `bodyData` downstream
+ * consumes the body itself and would fail on an already-consumed stream.
+ */
+
+// Slack's documented replay window. Slack itself recommends rejecting anything older than
+// five minutes; we apply it symmetrically to also reject far-future timestamps, which a
+// forger would need in order to mint a signature that stays valid.
+export const MAX_TIMESTAMP_SKEW_SECONDS = 60 * 5;
+
+// Reject oversized bodies before doing any HMAC work, so an unauthenticated caller cannot
+// force unbounded hashing. Real Slack payloads are a few KB; Slack does not document a hard
+// cap, so 1 MiB is a generous ceiling (matches github-webhook-hmac-handler.js).
+export const MAX_BODY_BYTES = 1024 * 1024;
+
+// "v0=" plus a 64-char lowercase hex HMAC-SHA256 digest. Checked before timingSafeEqual so a
+// malformed header cannot throw on a Buffer length mismatch.
+const SIGNATURE_PATTERN = /^v0=[a-f0-9]{64}$/;
+
+const SIGNATURE_HEADER = 'x-slack-signature';
+const TIMESTAMP_HEADER = 'x-slack-request-timestamp';
+
+// Only the Slack-facing route. Everything else passes through untouched. `/slack/channels/
+// invite-by-user-id` is deliberately NOT included: it is an inbound Adobe-side call
+// authenticated by RouteScopedLegacyApiKeyHandler, not a request signed by Slack.
+const SLACK_SIGNED_PATHS = new Set(['/slack/events', 'slack/events']);
+
+/**
+ * Constant-time comparison of the received signature against the expected one.
+ * Both operands are known to be 67 ASCII chars ("v0=" + 64 hex) because the caller has already
+ * matched SIGNATURE_PATTERN and we generate the expected value ourselves, so timingSafeEqual
+ * cannot throw on differing lengths.
+ *
+ * @param {string} received - the `x-slack-signature` header value.
+ * @param {string} expected - the locally computed signature.
+ * @returns {boolean} true when they match.
+ */
+function signaturesMatch(received, expected) {
+  return crypto.timingSafeEqual(Buffer.from(received, 'utf8'), Buffer.from(expected, 'utf8'));
+}
+
+/**
+ * Computes the Slack v0 signature for a raw body.
+ *
+ * @param {string} signingSecret - the Slack app signing secret.
+ * @param {string} timestamp - the raw `x-slack-request-timestamp` value (unix seconds).
+ * @param {string} rawBody - the exact request body bytes, as text.
+ * @returns {string} the `v0=<hex>` signature.
+ */
+export function computeSlackSignature(signingSecret, timestamp, rawBody) {
+  const baseString = `v0:${timestamp}:${rawBody}`;
+  return `v0=${crypto.createHmac('sha256', signingSecret).update(baseString, 'utf8').digest('hex')}`;
+}
+
+/**
+ * True when the route is one Slack signs. Tolerates a suffix with or without a leading slash
+ * (production sets it with one; some test harnesses do not).
+ *
+ * @param {object} context - the universal context.
+ * @returns {boolean}
+ */
+function isSlackSignedRoute(context) {
+  return SLACK_SIGNED_PATHS.has(context?.pathInfo?.suffix || '');
+}
+
+/**
+ * Wraps a universal function so that requests to `/slack/events` must carry a valid Slack
+ * request signature. Fails closed: any missing, malformed, stale, oversized or mismatching
+ * input yields 401 and the request never reaches the Slack controller.
+ *
+ * @param {UniversalFunction} fn - the function to wrap.
+ * @returns {UniversalFunction} the wrapped function.
+ */
+export function slackSignatureWrapper(fn) {
+  return async (request, context) => {
+    if (!isSlackSignedRoute(context)) {
+      return fn(request, context);
+    }
+
+    const { log = console, pathInfo: { headers = {} } = {} } = context;
+    // enrichPathInfo lowercases header names via request.headers.plain().
+    const signature = headers[SIGNATURE_HEADER];
+    const timestamp = headers[TIMESTAMP_HEADER];
+
+    const unauthorized = (reason) => {
+      // Log the reason, never the signature, body or secret.
+      log.warn(`Slack signature verification failed: ${reason}`);
+      return new Response('Unauthorized', {
+        status: 401,
+        headers: { 'x-error': 'slack signature verification failed' },
+      });
+    };
+
+    const { SLACK_SIGNING_SECRET: signingSecret } = context.env || {};
+    // Fail closed on misconfiguration. An unsigned-but-accepted request is exactly the
+    // vulnerability being fixed, so a missing secret must never degrade to "allow".
+    if (!hasText(signingSecret)) {
+      return unauthorized('SLACK_SIGNING_SECRET is not configured');
+    }
+
+    if (!hasText(signature) || !hasText(timestamp)) {
+      return unauthorized('missing signature or timestamp header');
+    }
+
+    if (!SIGNATURE_PATTERN.test(signature)) {
+      return unauthorized('malformed signature header');
+    }
+
+    // Slack sends unix seconds. Reject anything non-numeric outright rather than letting
+    // Number() coerce (e.g. '' -> 0, '  12 ' -> 12) into a value that could pass the window.
+    if (!/^\d+$/.test(timestamp)) {
+      return unauthorized('malformed timestamp header');
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (Math.abs(nowSeconds - Number(timestamp)) > MAX_TIMESTAMP_SKEW_SECONDS) {
+      return unauthorized('timestamp outside the allowed replay window');
+    }
+
+    // Content-Length is an honest-client hint only (a forger can omit or lie about it); the
+    // post-read byte length below is the real enforcement. Checking it first lets us reject
+    // a declared-oversized body without buffering it.
+    const contentLength = Number(request.headers.get('content-length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+      return unauthorized('request body too large');
+    }
+
+    let rawBody;
+    try {
+      // clone() so the body remains readable by multipartFormData / bodyData downstream.
+      rawBody = await request.clone().text();
+    } catch (e) {
+      return unauthorized(`could not read request body: ${e.message}`);
+    }
+
+    if (Buffer.byteLength(rawBody, 'utf8') > MAX_BODY_BYTES) {
+      return unauthorized('request body too large');
+    }
+
+    const expected = computeSlackSignature(signingSecret, timestamp, rawBody);
+    if (!signaturesMatch(signature, expected)) {
+      return unauthorized('signature mismatch');
+    }
+
+    return fn(request, context);
+  };
+}
+
+export default slackSignatureWrapper;

--- a/src/support/slack/signature-wrapper.js
+++ b/src/support/slack/signature-wrapper.js
@@ -14,6 +14,7 @@ import crypto from 'crypto';
 import { Response } from '@adobe/fetch';
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 import { hasText } from '@adobe/spacecat-shared-utils';
+import { checkBodySize } from '../../utils/validations.js';
 
 /**
  * Slack request-signature verification (VULN-39365).
@@ -59,6 +60,16 @@ const TIMESTAMP_HEADER = 'x-slack-request-timestamp';
 // authenticated by RouteScopedLegacyApiKeyHandler, not a request signed by Slack.
 const SLACK_SIGNED_PATHS = new Set(['/slack/events', 'slack/events']);
 
+// Fail-closed backstop, matched against the RAW request URL rather than context.pathInfo.
+//
+// `isSlackSignedRoute` keys off `context.pathInfo.suffix`, which is populated upstream by
+// `enrichPathInfo`. If this wrapper were ever re-ordered to run BEFORE that (or pathInfo were
+// otherwise unpopulated), `suffix` would be empty, the guard would be skipped, and the request
+// would pass through UNVERIFIED -- i.e. fail open, which is precisely the VULN-39365 surface.
+// Consulting the request URL as well makes the guard independent of wrapper ordering: the worst
+// case becomes a 401 on a path nothing serves, never an unverified Slack payload.
+const SLACK_EVENTS_URL_PATH = /(^|\/)slack\/events\/?$/;
+
 // CORS preflight is answered by `run()` in src/index.js with a 204 before any route handler is
 // reached, and carries no body to sign. Excluding it keeps that behaviour intact rather than
 // turning every preflight into a 401. Every other method on the guarded suffix is verified --
@@ -101,17 +112,35 @@ export function computeSlackSignature(signingSecret, timestamp, rawBody) {
 
 /**
  * True when the request must carry a valid Slack signature: the route is one Slack signs, and
- * the method is one that can carry a signed body. Tolerates a suffix with or without a leading
- * slash (production sets it with one; some test harnesses do not).
+ * the method is one that can carry a signed body.
  *
+ * The route is resolved from `context.pathInfo.suffix` when available (tolerating a suffix with
+ * or without a leading slash), and otherwise from the raw request URL. That fallback is what
+ * makes the guard fail CLOSED rather than open if `pathInfo` is ever unpopulated -- see
+ * SLACK_EVENTS_URL_PATH.
+ *
+ * @param {Request} request - the universal request.
  * @param {object} context - the universal context.
  * @returns {boolean}
  */
-function isSlackSignedRoute(context) {
-  if (!SLACK_SIGNED_PATHS.has(context?.pathInfo?.suffix || '')) {
+function isSlackSignedRoute(request, context) {
+  // Prefer pathInfo.method (set by enrichPathInfo), fall back to the request's own method.
+  const method = (context?.pathInfo?.method || request?.method || '').toUpperCase();
+  if (UNVERIFIED_METHODS.has(method)) {
     return false;
   }
-  return !UNVERIFIED_METHODS.has((context?.pathInfo?.method || '').toUpperCase());
+
+  const suffix = context?.pathInfo?.suffix;
+  if (typeof suffix === 'string' && suffix.length > 0) {
+    return SLACK_SIGNED_PATHS.has(suffix);
+  }
+
+  try {
+    return SLACK_EVENTS_URL_PATH.test(new URL(request.url).pathname);
+  } catch {
+    // An unparseable URL cannot be shown to be a non-Slack route, so guard it.
+    return true;
+  }
 }
 
 /**
@@ -124,7 +153,7 @@ function isSlackSignedRoute(context) {
  */
 export function slackSignatureWrapper(fn) {
   return async (request, context) => {
-    if (!isSlackSignedRoute(context)) {
+    if (!isSlackSignedRoute(request, context)) {
       return fn(request, context);
     }
 
@@ -205,7 +234,11 @@ export function slackSignatureWrapper(fn) {
     }
 
     const bodyBytes = Buffer.byteLength(rawBody, 'utf8');
-    if (bodyBytes > MAX_BODY_BYTES) {
+    // Reuse the repo's shared body-size helper for the post-read (authoritative) check. The
+    // Content-Length pre-check above has no equivalent there: it measures a client-supplied
+    // header, not a body, and exists only to reject a declared-oversized request before
+    // buffering it.
+    if (!checkBodySize(rawBody, MAX_BODY_BYTES)) {
       return unauthorized('body_too_large', { bodyBytes, maxBytes: MAX_BODY_BYTES });
     }
 

--- a/src/utils/slack/base.js
+++ b/src/utils/slack/base.js
@@ -23,6 +23,7 @@ import { parse } from 'csv';
 
 import { Blocks, Elements, Message } from 'slack-block-builder';
 import { isAuditForAllUrls } from '../../support/audit-run-scope.js';
+import { assertSlackFileUrl } from './file-url.js';
 
 export const BACKTICKS = '```';
 export const BOT_MENTION_REGEX = /^<@[^>]+>\s+/;
@@ -354,6 +355,8 @@ const wrapSayForThread = (say, threadTs) => {
  */
 const fetchFile = async (file, token) => {
   const fileUrl = file.url_private;
+  // Only ever send the bot token to a Slack-owned host (VULN-39365).
+  assertSlackFileUrl(fileUrl);
   const response = await fetch(fileUrl, {
     headers: { Authorization: `Bearer ${token}` },
     responseType: 'arraybuffer',

--- a/src/utils/slack/file-url.js
+++ b/src/utils/slack/file-url.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Allowlist for Slack file downloads (VULN-39365, defence in depth).
+ *
+ * Slack file objects carry a `url_private` that the service fetches with the bot token in an
+ * `Authorization: Bearer` header. Because the file object originates in the request payload,
+ * anyone who can reach a Slack handler with a forged payload can point `url_private` at a host
+ * they control and harvest the token from the outbound request.
+ *
+ * `slackSignatureWrapper` is the primary fix — it stops forged payloads reaching a handler at
+ * all. This module is the second layer: even with a valid signature (a compromised workspace, a
+ * malicious insider, or a future code path that reintroduces an unauthenticated entry point),
+ * the bot token is only ever sent to Slack-owned hosts.
+ *
+ * Note this must be an ALLOWLIST. `src/support/url-safety.js#isSafeDomain` is a denylist of
+ * private/internal ranges; an attacker-controlled *public* host passes it unharmed, so it is
+ * not a substitute here.
+ */
+
+// Slack serves file downloads from files.slack.com, and *.slack.com more broadly
+// (e.g. <workspace>.slack.com). Anything else is rejected.
+const ALLOWED_SLACK_FILE_HOSTS = new Set(['slack.com', 'files.slack.com']);
+const ALLOWED_SLACK_HOST_SUFFIX = '.slack.com';
+
+/**
+ * True when the URL is an https URL served by a Slack-owned host, and therefore a safe
+ * destination for a request carrying the bot token.
+ *
+ * Uses the WHATWG URL parser so that userinfo tricks (`https://files.slack.com@evil.test/`),
+ * encoded hosts and alternate IP notations are normalised before the host is compared — the
+ * parser assigns `hostname` from the real authority, not the userinfo prefix.
+ *
+ * @param {string} url - the candidate URL (typically a Slack file's `url_private`).
+ * @returns {boolean} true when the URL may be fetched with the bot token attached.
+ */
+export function isSlackFileUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) {
+    return false;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  // Plaintext http would expose the bearer token on the wire.
+  if (parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  return ALLOWED_SLACK_FILE_HOSTS.has(hostname) || hostname.endsWith(ALLOWED_SLACK_HOST_SUFFIX);
+}
+
+/**
+ * Throws unless the URL is a Slack-owned https URL. Call this immediately before any fetch that
+ * attaches the Slack bot token.
+ *
+ * The rejected URL is deliberately NOT interpolated into the error message: the message reaches
+ * Slack and the logs, and the URL is attacker-controlled.
+ *
+ * @param {string} url - the candidate URL.
+ * @throws {Error} when the URL is not a Slack-owned https URL.
+ */
+export function assertSlackFileUrl(url) {
+  if (!isSlackFileUrl(url)) {
+    throw new Error('Refusing to download file: URL is not a Slack-hosted https URL.');
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -233,8 +233,14 @@ describe('Index Tests', () => {
     });
 
     beforeEach(() => {
+      // Deliberately set ONLY `suffix`, which in production comes from the Lambda adapter and
+      // NOT from enrichPathInfo. `method` and `headers` are left unset so they must be
+      // populated by the real enrichPathInfo in the chain -- otherwise these tests would
+      // supply the pathInfo the wrapper reads and would stay green even if a future `.with()`
+      // reorder broke the ordering they exist to protect.
       context.pathInfo.suffix = slackPath;
-      context.pathInfo.method = 'POST';
+      delete context.pathInfo.method;
+      delete context.pathInfo.headers;
     });
 
     it('rejects an unsigned POST before it reaches the Slack controller', async () => {
@@ -300,8 +306,6 @@ describe('Index Tests', () => {
     it('does not process Slack events over GET', async () => {
       // The GET route is gone. The wrapper guards every non-preflight method on this suffix,
       // so an unsigned GET is rejected at the signature layer rather than reaching a handler.
-      context.pathInfo.method = 'GET';
-
       const resp = await main(new Request(`${baseUrl}${slackPath}`), context);
 
       expect(resp.status).to.equal(401);
@@ -309,8 +313,6 @@ describe('Index Tests', () => {
     });
 
     it('still answers an OPTIONS preflight on the Slack route', async () => {
-      context.pathInfo.method = 'OPTIONS';
-
       const resp = await main(
         new Request(`${baseUrl}${slackPath}`, { method: 'OPTIONS' }),
         context,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,7 @@
  */
 
 import { Request } from '@adobe/fetch';
+import crypto from 'crypto';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
@@ -208,6 +209,115 @@ describe('Index Tests', () => {
 
     expect(resp.status).to.equal(404);
     expect(resp.headers.plain()['x-error']).to.equal('wrong path format');
+  });
+
+  // VULN-39365. These exercise the REAL middleware chain in src/index.js, not the wrapper in
+  // isolation: a correct slackSignatureWrapper that is mis-ordered or not mounted would leave
+  // the original forged-payload vulnerability live while the unit tests still passed.
+  //
+  // A `url_verification` body is used deliberately -- SlackController short-circuits it before
+  // initialising Bolt, so these assert the middleware chain without standing up a Slack app.
+  describe('Slack signature verification (wired through main)', () => {
+    const slackPath = '/slack/events';
+    const slackBody = JSON.stringify({ type: 'url_verification', challenge: 'challenge-token' });
+
+    const sign = (body, timestamp) => `v0=${crypto
+      .createHmac('sha256', slackSigningSecret)
+      .update(`v0:${timestamp}:${body}`, 'utf8')
+      .digest('hex')}`;
+
+    const slackRequest = (body, headers) => new Request(`${baseUrl}${slackPath}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body,
+    });
+
+    beforeEach(() => {
+      context.pathInfo.suffix = slackPath;
+      context.pathInfo.method = 'POST';
+    });
+
+    it('rejects an unsigned POST before it reaches the Slack controller', async () => {
+      const resp = await main(slackRequest(slackBody), context);
+
+      expect(resp.status).to.equal(401);
+      expect(resp.headers.plain()['x-error']).to.equal('slack signature verification failed');
+      // Proves the wrapper ran BEFORE the controller: otherwise the url_verification
+      // short-circuit would have echoed the challenge back.
+      expect(await resp.text()).to.not.contain('challenge-token');
+    });
+
+    it('rejects a POST signed with the wrong secret', async () => {
+      const timestamp = `${Math.floor(Date.now() / 1000)}`;
+      const forged = `v0=${crypto.createHmac('sha256', 'not-the-secret').update(`v0:${timestamp}:${slackBody}`, 'utf8').digest('hex')}`;
+
+      const resp = await main(slackRequest(slackBody, {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': forged,
+      }), context);
+
+      expect(resp.status).to.equal(401);
+    });
+
+    it('lets a correctly signed POST through with its body still parseable', async () => {
+      const timestamp = `${Math.floor(Date.now() / 1000)}`;
+
+      const resp = await main(slackRequest(slackBody, {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': sign(slackBody, timestamp),
+      }), context);
+
+      // Reaching the controller AND echoing the challenge proves bodyData still parsed the
+      // body after the wrapper consumed a clone of it.
+      expect(resp.status).to.equal(200);
+      expect(await resp.json()).to.deep.equal({ challenge: 'challenge-token' });
+    });
+
+    it('verifies a signed form-urlencoded interactive payload end to end', async () => {
+      // Slack posts interactive payloads (button clicks, modals) as form-urlencoded and signs
+      // the ENCODED body. This is the shape that reaches privileged handlers like approveOrg.
+      const payload = JSON.stringify({ type: 'block_actions', actions: [{ action_id: 'noop' }] });
+      const body = `payload=${encodeURIComponent(payload)}`;
+      const timestamp = `${Math.floor(Date.now() / 1000)}`;
+
+      const resp = await main(slackRequest(body, {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': sign(body, timestamp),
+      }), context);
+
+      // Two things are under test, and both are proven by getting PAST these two layers:
+      //  1. the signature verified over the form-encoded bytes (not a 401), and
+      //  2. bodyData still parsed the body after the wrapper read a clone of it -- a broken
+      //     clone would surface as bodyData's own 400 'error parsing request body'.
+      // What Bolt then does with the payload is the controller's business, not this test's.
+      const xError = resp.headers.plain()['x-error'];
+      expect(resp.status).to.not.equal(401);
+      expect(xError).to.not.equal('slack signature verification failed');
+      expect(xError).to.not.equal('error parsing request body');
+    });
+
+    it('does not process Slack events over GET', async () => {
+      // The GET route is gone. The wrapper guards every non-preflight method on this suffix,
+      // so an unsigned GET is rejected at the signature layer rather than reaching a handler.
+      context.pathInfo.method = 'GET';
+
+      const resp = await main(new Request(`${baseUrl}${slackPath}`), context);
+
+      expect(resp.status).to.equal(401);
+      expect(await resp.text()).to.not.contain('challenge-token');
+    });
+
+    it('still answers an OPTIONS preflight on the Slack route', async () => {
+      context.pathInfo.method = 'OPTIONS';
+
+      const resp = await main(
+        new Request(`${baseUrl}${slackPath}`, { method: 'OPTIONS' }),
+        context,
+      );
+
+      expect(resp.status).to.equal(204);
+    });
   });
 
   it('handles options request', async () => {

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -764,7 +764,6 @@ describe('getRouteHandlers', () => {
       'POST /sites',
       'GET /sites.csv',
       'GET /sites.xlsx',
-      'GET /slack/events',
       'POST /slack/events',
       'GET /trigger',
       'POST /event/fulfillment',

--- a/test/support/access-control-util.test.js
+++ b/test/support/access-control-util.test.js
@@ -264,7 +264,9 @@ describe('Access Control Util', () => {
   });
 
   // Test anonymous endpoints
-  it('handles anonymous Slack endpoints', () => {
+  it('does NOT treat GET /slack/events as anonymous (VULN-39365)', () => {
+    // The GET route was removed. It must no longer be granted an anonymous (admin-equivalent)
+    // AuthInfo, otherwise this registry drifts from routes/index.js and authWrapper.
     const slackContext = {
       log: { info: logSpy },
       pathInfo: {
@@ -273,9 +275,7 @@ describe('Access Control Util', () => {
       },
     };
 
-    const util = AccessControlUtil.fromContext(slackContext);
-    expect(util.authInfo).to.exist;
-    expect(util.authInfo.getProfile().user_id).to.equal('anonymous');
+    expect(() => AccessControlUtil.fromContext(slackContext)).to.throw('Missing authInfo');
   });
 
   it('handles anonymous site detection endpoints', () => {

--- a/test/support/slack/commands/onboard.test.js
+++ b/test/support/slack/commands/onboard.test.js
@@ -813,7 +813,7 @@ describe('OnboardCommand', () => {
 
   describe('Batch Onboarding from CSV', () => {
     beforeEach(() => {
-      slackContext.files = [{ name: 'test.csv', url_private: 'https://mock-csv.com' }];
+      slackContext.files = [{ name: 'test.csv', url_private: 'https://files.slack.com/files-pri/T1-F2/test.csv' }];
       slackContext.botToken = 'test-token';
     });
 
@@ -823,7 +823,13 @@ describe('OnboardCommand', () => {
         ['https://example2.com', '000000000000000000000000@AdobeOrg'],
       ];
 
-      parseCSVStub.withArgs('https://mock-csv.com', 'test-token').resolves(mockCSVData);
+      // parseCSV receives the Slack file OBJECT (not its URL) plus the bot token. Matching on
+      // the object is what makes this stub actually apply -- a URL-string matcher silently
+      // never matched, so the test previously fell through to the default `[]` stub and
+      // asserted nothing about the valid-CSV path.
+      parseCSVStub
+        .withArgs(sinon.match({ url_private: 'https://files.slack.com/files-pri/T1-F2/test.csv' }), 'test-token')
+        .resolves(mockCSVData);
 
       dataAccessStub.Organization.findByImsOrgId.resolves({ organizationId: 'existing-org-123' });
       dataAccessStub.Organization.create.resolves(null);
@@ -834,12 +840,21 @@ describe('OnboardCommand', () => {
         getBaseURL: () => 'https://example1.com',
       });
 
-      const args = ['default'];
+      // 'demo' is a real profile in static/onboard/profiles.json. The previous 'default' does
+      // not exist, so loadProfileConfig threw and the batch loop never ran -- which the old
+      // `expect(say.called)` assertion could not detect.
+      const args = ['demo'];
       const command = OnboardCommand(context);
 
       await command.handleExecution(args, slackContext);
 
-      // Verify that the function executed successfully
+      // Assert the real side effect of the valid-CSV path: both rows were onboarded, and the
+      // file object (not a URL string) was handed to parseCSV.
+      expect(parseCSVStub.calledWith(
+        sinon.match({ url_private: 'https://files.slack.com/files-pri/T1-F2/test.csv' }),
+        'test-token',
+      )).to.be.true;
+      expect(onboardSingleSiteStub.callCount).to.equal(mockCSVData.length);
       expect(slackContext.say.called).to.be.true;
     });
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -165,7 +165,7 @@ describe('RunAuditCommand', () => {
         getId: () => '123',
       });
       dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('lhs-mobile', ['LLMO']));
-      const fileUrl = 'https://example.com/sites.csv';
+      const fileUrl = 'https://files.slack.com/sites.csv';
       slackContext.files = [
         {
           name: 'sites.csv',
@@ -190,7 +190,7 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'sites.csv',
-          url_private: 'https://example.com/sites.csv',
+          url_private: 'https://files.slack.com/sites.csv',
         },
       ];
       await command.handleExecution(['site.com'], slackContext);
@@ -204,10 +204,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1\nhttps://valid.site/page-2\ninvalid-url');
 
@@ -240,12 +240,12 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
       // Generate 500 valid URLs — all sent in a single message (no batching)
       const urls = Array.from({ length: 500 }, (_, i) => `https://valid.site/page-${i + 1}`);
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, urls.join('\n'));
 
@@ -261,10 +261,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'invalid-url');
 
@@ -279,11 +279,11 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls1.csv',
-          url_private: 'https://example.com/urls1.csv',
+          url_private: 'https://files.slack.com/urls1.csv',
         },
         {
           name: 'urls2.csv',
-          url_private: 'https://example.com/urls2.csv',
+          url_private: 'https://files.slack.com/urls2.csv',
         },
       ];
 
@@ -298,7 +298,7 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.txt',
-          url_private: 'https://example.com/urls.txt',
+          url_private: 'https://files.slack.com/urls.txt',
         },
       ];
 
@@ -315,10 +315,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1');
 
@@ -340,10 +340,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1');
 
@@ -363,10 +363,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1');
 
@@ -386,10 +386,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1');
 
@@ -414,10 +414,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1');
 
@@ -434,10 +434,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1');
 
@@ -453,11 +453,11 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'sites1.csv',
-          url_private: 'https://example.com/sites1.csv',
+          url_private: 'https://files.slack.com/sites1.csv',
         },
         {
           name: 'sites2.csv',
-          url_private: 'https://example.com/sites2.csv',
+          url_private: 'https://files.slack.com/sites2.csv',
         },
       ];
       await command.handleExecution(['', 'all'], slackContext);
@@ -469,7 +469,7 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'sites.txt',
-          url_private: 'https://example.com/sites.txt',
+          url_private: 'https://files.slack.com/sites.txt',
         },
       ];
       await command.handleExecution(['', 'all'], slackContext);
@@ -481,10 +481,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'sites.csv',
-          url_private: 'https://example.com/sites.csv',
+          url_private: 'https://files.slack.com/sites.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/sites.csv')
         .reply(200, 'invalid-url,uuidv4\n');
 
@@ -535,10 +535,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'sites.csv',
-          url_private: 'https://example.com/sites.csv',
+          url_private: 'https://files.slack.com/sites.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/sites.csv')
         .reply(401, 'Unauthorized');
 
@@ -835,10 +835,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1\nhttps://valid.site/page-2');
 
@@ -856,10 +856,10 @@ describe('RunAuditCommand', () => {
       slackContext.files = [
         {
           name: 'urls.csv',
-          url_private: 'https://example.com/urls.csv',
+          url_private: 'https://files.slack.com/urls.csv',
         },
       ];
-      nock('https://example.com')
+      nock('https://files.slack.com')
         .get('/urls.csv')
         .reply(200, 'https://valid.site/page-1');
 

--- a/test/support/slack/commands/run-audit.test.js
+++ b/test/support/slack/commands/run-audit.test.js
@@ -233,6 +233,29 @@ describe('RunAuditCommand', () => {
       expect(slackContext.say.secondCall.args[0]).to.equal(':white_check_mark: prerender audit queued for 2 URLs.');
     });
 
+    it('refuses a prerender CSV whose url_private is not Slack-hosted, without a 500 (VULN-39365)', async () => {
+      const site = { getId: () => '123' };
+      dataAccessStub.Site.findByBaseURL.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves(createDefaultConfigurationMock('prerender', ['LLMO']));
+      slackContext.files = [
+        {
+          name: 'urls.csv',
+          url_private: 'https://attacker.example.com/collect',
+        },
+      ];
+      // No nock interceptor for the attacker host on purpose: if the guard failed to stop the
+      // fetch, the request would be attempted and nock would surface it.
+
+      const command = RunAuditCommand(context);
+      await command.handleExecution(['site.com', 'prerender'], slackContext);
+
+      // The throw from assertSlackFileUrl is caught by the command and reported to Slack,
+      // rather than escaping as an unhandled 500.
+      const said = slackContext.say.getCalls().map((c) => String(c.args[0])).join('\n');
+      expect(said).to.contain('not a Slack-hosted https URL');
+      expect(sqsStub.sendMessage).to.have.not.been.called;
+    });
+
     it('sends a single SQS message for large prerender CSV', async () => {
       const site = { getId: () => '123' };
       dataAccessStub.Site.findByBaseURL.resolves(site);

--- a/test/support/slack/commands/run-page-citability.test.js
+++ b/test/support/slack/commands/run-page-citability.test.js
@@ -104,8 +104,8 @@ describe('RunPageCitabilityCommand', () => {
     it('rejects multiple CSV files', async () => {
       dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-123' });
       slackContext.files = [
-        { name: 'file1.csv', url_private: 'https://example.com/file1.csv' },
-        { name: 'file2.csv', url_private: 'https://example.com/file2.csv' },
+        { name: 'file1.csv', url_private: 'https://files.slack.com/file1.csv' },
+        { name: 'file2.csv', url_private: 'https://files.slack.com/file2.csv' },
       ];
       const command = RunPageCitabilityCommand(context);
 
@@ -117,7 +117,7 @@ describe('RunPageCitabilityCommand', () => {
     it('rejects non-CSV files', async () => {
       dataAccessStub.Site.findByBaseURL.resolves({ getId: () => 'site-123' });
       slackContext.files = [
-        { name: 'file.txt', url_private: 'https://example.com/file.txt' },
+        { name: 'file.txt', url_private: 'https://files.slack.com/file.txt' },
       ];
       const command = RunPageCitabilityCommand(context);
 

--- a/test/support/slack/commands/run-scrape.test.js
+++ b/test/support/slack/commands/run-scrape.test.js
@@ -209,7 +209,7 @@ describe('RunScrapeCommand', () => {
       slackContext.files = [
         {
           name: 'sites.csv',
-          url_private: 'https://example.com/sites.csv',
+          url_private: 'https://files.slack.com/sites.csv',
         },
       ];
 
@@ -223,11 +223,11 @@ describe('RunScrapeCommand', () => {
       slackContext.files = [
         {
           name: 'sites1.csv',
-          url_private: 'https://example.com/sites1.csv',
+          url_private: 'https://files.slack.com/sites1.csv',
         },
         {
           name: 'sites2.csv',
-          url_private: 'https://example.com/sites2.csv',
+          url_private: 'https://files.slack.com/sites2.csv',
         },
       ];
 
@@ -241,7 +241,7 @@ describe('RunScrapeCommand', () => {
       slackContext.files = [
         {
           name: 'sites.txt',
-          url_private: 'https://example.com/sites.txt',
+          url_private: 'https://files.slack.com/sites.txt',
         },
       ];
 
@@ -251,7 +251,7 @@ describe('RunScrapeCommand', () => {
     });
 
     it('triggers scrapes for all sites in the CSV file', async () => {
-      const fileUrl = 'https://example.com/sites.csv';
+      const fileUrl = 'https://files.slack.com/sites.csv';
       dataAccessStub.Site.findByBaseURL.resolves({
         getId: () => '123',
         getSiteTopPagesBySourceAndGeo: sandbox.stub().resolves([
@@ -281,7 +281,7 @@ describe('RunScrapeCommand', () => {
     });
 
     it('warns when no scrape jobs are triggered from CSV', async () => {
-      const fileUrl = 'https://example.com/sites.csv';
+      const fileUrl = 'https://files.slack.com/sites.csv';
       dataAccessStub.Site.findByBaseURL.resolves(null);
       slackContext.files = [
         {
@@ -300,7 +300,7 @@ describe('RunScrapeCommand', () => {
     });
 
     it('handles failing scrape for a site in the CSV file', async () => {
-      const fileUrl = 'https://example.com/sites.csv';
+      const fileUrl = 'https://files.slack.com/sites.csv';
       dataAccessStub.Site.findByBaseURL.onCall(0).resolves({
         getId: () => '123',
         getSiteTopPagesBySourceAndGeo: sandbox.stub().resolves([

--- a/test/support/slack/commands/toggle-site-audit.test.js
+++ b/test/support/slack/commands/toggle-site-audit.test.js
@@ -273,6 +273,26 @@ describe('UpdateSitesAuditsCommand', () => {
   });
 
   describe('CSV bulk operations', () => {
+    it('refuses a CSV whose url_private is not a Slack-hosted URL (VULN-39365)', async () => {
+      // The bot token must never be sent to an attacker-controlled host. toggle-site-audit
+      // does not use the shared fetchFile helper, so it needs its own guard and its own test.
+      const args = ['disable', 'demo'];
+      const command = ToggleSiteAuditCommand(contextMock);
+
+      slackContextMock.files = [{
+        name: 'sites.csv',
+        url_private: 'https://attacker.example.com/collect',
+      }];
+
+      await command.handleExecution(args, slackContextMock);
+
+      expect(slackContextMock.say.calledWith(sinon.match(/not a Slack-hosted https URL/))).to.be.true;
+      // The decisive assertion: no outbound request carrying the token was made at all.
+      expect(fetchStub.called).to.be.false;
+      // And the rejected (attacker-controlled) URL is not echoed back into Slack.
+      expect(slackContextMock.say.calledWith(sinon.match(/attacker\.example\.com/))).to.be.false;
+    });
+
     it('should show deprecation when enable is requested with CSV profile', async () => {
       const args = ['enable', 'demo'];
       const command = ToggleSiteAuditCommand(contextMock);

--- a/test/support/slack/commands/toggle-site-audit.test.js
+++ b/test/support/slack/commands/toggle-site-audit.test.js
@@ -279,7 +279,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'https://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       await command.handleExecution(args, slackContextMock);
@@ -295,7 +295,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'https://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
       dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves(site);
       dataAccessMock.Site.findByBaseURL.withArgs('https://site2.com').resolves(site);
@@ -311,7 +311,7 @@ describe('UpdateSitesAuditsCommand', () => {
     it('should handle errors during audit disabling in bulk processing', async () => {
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves(site);
@@ -345,7 +345,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       const command = ToggleSiteAuditCommand(contextMock);
@@ -362,7 +362,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       const command = ToggleSiteAuditCommand(contextMock);
@@ -379,7 +379,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       const command = ToggleSiteAuditCommand(contextMock);
@@ -395,7 +395,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       const command = ToggleSiteAuditCommand(contextMock);
@@ -412,7 +412,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       const command = ToggleSiteAuditCommand(contextMock);
@@ -429,7 +429,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       dataAccessMock.Site.findByBaseURL.withArgs('https://site1.com').resolves(site);
@@ -457,7 +457,7 @@ describe('UpdateSitesAuditsCommand', () => {
 
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       const command = ToggleSiteAuditCommand(contextMock);
@@ -471,7 +471,7 @@ describe('UpdateSitesAuditsCommand', () => {
     it('should handle invalid profile name', async () => {
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'http://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       const command = ToggleSiteAuditCommand(contextMock);

--- a/test/support/slack/commands/toggle-site-import.test.js
+++ b/test/support/slack/commands/toggle-site-import.test.js
@@ -389,7 +389,7 @@ describe('ToggleSiteImportCommand', () => {
       // Setup test environment with a CSV file
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'https://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
 
       // Call with only the enableImport parameter
@@ -438,7 +438,7 @@ describe('ToggleSiteImportCommand', () => {
     beforeEach(() => {
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'https://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
     });
 
@@ -457,7 +457,7 @@ describe('ToggleSiteImportCommand', () => {
 
       // File object should have url_private property (not string content)
       expect(fileArg).to.be.an('object');
-      expect(fileArg.url_private).to.equal('https://mock-url');
+      expect(fileArg.url_private).to.equal('https://files.slack.com/mock-url');
       expect(fileArg.name).to.equal('sites.csv');
 
       // Token should be passed
@@ -581,7 +581,7 @@ describe('ToggleSiteImportCommand', () => {
     beforeEach(() => {
       slackContextMock.files = [{
         name: 'sites.csv',
-        url_private: 'https://mock-url',
+        url_private: 'https://files.slack.com/mock-url',
       }];
     });
 

--- a/test/support/slack/signature-wrapper.test.js
+++ b/test/support/slack/signature-wrapper.test.js
@@ -132,6 +132,27 @@ describe('slackSignatureWrapper', () => {
       expect(next).to.have.not.been.called;
     });
 
+    it('lets an OPTIONS preflight through unverified', async () => {
+      // CORS preflight carries no body to sign and is answered with a 204 by run(); turning it
+      // into a 401 would be a gratuitous behaviour change.
+      const context = buildContext({}, { pathInfo: { method: 'OPTIONS', suffix: '/slack/events', headers: {} } });
+
+      const result = await slackSignatureWrapper(next)(buildRequest('{}'), context);
+
+      expect(result).to.equal('downstream-called');
+    });
+
+    it('still guards non-POST, non-preflight methods on the Slack suffix', async () => {
+      // Deliberately wider than the single POST route the router exposes today, so re-adding a
+      // route on this path cannot silently create an unverified entry point.
+      const context = buildContext({}, { pathInfo: { method: 'GET', suffix: '/slack/events', headers: {} } });
+
+      const result = await slackSignatureWrapper(next)(buildRequest('{}'), context);
+
+      expect(result.status).to.equal(401);
+      expect(next).to.have.not.been.called;
+    });
+
     it('tolerates a context with no pathInfo', async () => {
       const result = await slackSignatureWrapper(next)(buildRequest('{}'), { log, env: {} });
 
@@ -259,6 +280,34 @@ describe('slackSignatureWrapper', () => {
       expect(result).to.equal('downstream-called');
     });
 
+    it('accepts a timestamp at the exact past edge of the replay window', async () => {
+      const edge = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS}`;
+      const { request, context } = signedDelivery('{}', { timestamp: edge });
+
+      expect(await slackSignatureWrapper(next)(request, context)).to.equal('downstream-called');
+    });
+
+    it('accepts a timestamp at the exact future edge of the replay window', async () => {
+      const edge = `${nowSeconds() + MAX_TIMESTAMP_SKEW_SECONDS}`;
+      const { request, context } = signedDelivery('{}', { timestamp: edge });
+
+      expect(await slackSignatureWrapper(next)(request, context)).to.equal('downstream-called');
+    });
+
+    it('rejects a timestamp one second past the window', async () => {
+      const stale = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS - 1}`;
+      const { request, context } = signedDelivery('{}', { timestamp: stale });
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('rejects a timestamp one second beyond the future window', async () => {
+      const ahead = `${nowSeconds() + MAX_TIMESTAMP_SKEW_SECONDS + 1}`;
+      const { request, context } = signedDelivery('{}', { timestamp: ahead });
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
     it('rejects a body larger than the cap before hashing it', async () => {
       const body = 'x'.repeat(MAX_BODY_BYTES + 1);
       const { request, context } = signedDelivery(body);
@@ -313,8 +362,11 @@ describe('slackSignatureWrapper', () => {
       await slackSignatureWrapper(next)(request, context);
 
       const logged = log.warn.getCalls().map((c) => c.args.join(' ')).join('\n');
-      expect(logged).to.contain('signature mismatch');
+      expect(logged).to.contain('reason=signature_mismatch');
+      // Diagnostic fields are safe to log; the secret, the signature and the body are not.
+      expect(logged).to.contain('bodyBytes=');
       expect(logged).to.not.contain(SIGNING_SECRET);
+      expect(logged).to.not.contain('attacker-guess');
       expect(logged).to.not.contain('do-not-log-me');
       expect(logged).to.not.contain('v0=');
     });

--- a/test/support/slack/signature-wrapper.test.js
+++ b/test/support/slack/signature-wrapper.test.js
@@ -153,8 +153,58 @@ describe('slackSignatureWrapper', () => {
       expect(next).to.have.not.been.called;
     });
 
-    it('tolerates a context with no pathInfo', async () => {
+    it('fails CLOSED when pathInfo is missing but the URL is the Slack route', async () => {
+      // Regression guard for the ordering hazard: if this wrapper ever ran before
+      // enrichPathInfo, `pathInfo.suffix` would be empty. Keying only off pathInfo would then
+      // skip the guard and pass the request through UNVERIFIED -- the VULN-39365 surface.
+      // The raw-URL backstop must reject instead.
       const result = await slackSignatureWrapper(next)(buildRequest('{}'), { log, env: {} });
+
+      expect(result.status).to.equal(401);
+      expect(next).to.have.not.been.called;
+    });
+
+    it('fails closed on the Slack URL even with a trailing slash', async () => {
+      const request = new Request('https://spacecat.test/slack/events/', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+
+      const result = await slackSignatureWrapper(next)(request, { log, env: {} });
+
+      expect(result.status).to.equal(401);
+    });
+
+    it('fails closed on the Slack URL behind an /api/v1 prefix', async () => {
+      const request = new Request('https://spacecat.test/api/v1/slack/events', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+
+      const result = await slackSignatureWrapper(next)(request, { log, env: {} });
+
+      expect(result.status).to.equal(401);
+    });
+
+    it('still passes a non-Slack URL through when pathInfo is missing', async () => {
+      const request = new Request('https://spacecat.test/sites', { method: 'GET' });
+
+      const result = await slackSignatureWrapper(next)(request, { log, env: {} });
+
+      expect(result).to.equal('downstream-called');
+    });
+
+    it('does not guard the sibling /slack/channels route', async () => {
+      // Authenticated by RouteScopedLegacyApiKeyHandler, not signed by Slack.
+      const request = new Request('https://spacecat.test/slack/channels/invite-by-user-id', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+
+      const result = await slackSignatureWrapper(next)(request, { log, env: {} });
 
       expect(result).to.equal('downstream-called');
     });
@@ -271,41 +321,57 @@ describe('slackSignatureWrapper', () => {
       expectUnauthorized(await slackSignatureWrapper(next)(request, context));
     });
 
-    it('accepts a timestamp at the edge of the replay window', async () => {
-      const edge = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS + 2}`;
-      const { request, context } = signedDelivery('{}', { timestamp: edge });
+    // Boundary cases are pinned with fake timers: with the real clock a one-second boundary can
+    // flake under CI load, and the exact +/-MAX assertions would not be exact.
+    describe('replay-window boundaries (fake timers)', () => {
+      let clock;
 
-      const result = await slackSignatureWrapper(next)(request, context);
+      beforeEach(() => {
+        clock = sandbox.useFakeTimers({ now: 1_700_000_000_000, toFake: ['Date'] });
+      });
 
-      expect(result).to.equal('downstream-called');
-    });
+      afterEach(() => {
+        clock.restore();
+      });
 
-    it('accepts a timestamp at the exact past edge of the replay window', async () => {
-      const edge = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS}`;
-      const { request, context } = signedDelivery('{}', { timestamp: edge });
+      it('accepts a timestamp at the exact past edge of the replay window', async () => {
+        const edge = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS}`;
+        const { request, context } = signedDelivery('{}', { timestamp: edge });
 
-      expect(await slackSignatureWrapper(next)(request, context)).to.equal('downstream-called');
-    });
+        expect(await slackSignatureWrapper(next)(request, context)).to.equal('downstream-called');
+      });
 
-    it('accepts a timestamp at the exact future edge of the replay window', async () => {
-      const edge = `${nowSeconds() + MAX_TIMESTAMP_SKEW_SECONDS}`;
-      const { request, context } = signedDelivery('{}', { timestamp: edge });
+      it('accepts a timestamp at the exact future edge of the replay window', async () => {
+        const edge = `${nowSeconds() + MAX_TIMESTAMP_SKEW_SECONDS}`;
+        const { request, context } = signedDelivery('{}', { timestamp: edge });
 
-      expect(await slackSignatureWrapper(next)(request, context)).to.equal('downstream-called');
-    });
+        expect(await slackSignatureWrapper(next)(request, context)).to.equal('downstream-called');
+      });
 
-    it('rejects a timestamp one second past the window', async () => {
-      const stale = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS - 1}`;
-      const { request, context } = signedDelivery('{}', { timestamp: stale });
+      it('rejects a timestamp exactly one second past the window', async () => {
+        const stale = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS - 1}`;
+        const { request, context } = signedDelivery('{}', { timestamp: stale });
 
-      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
-    });
+        expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+      });
 
-    it('rejects a timestamp one second beyond the future window', async () => {
-      const ahead = `${nowSeconds() + MAX_TIMESTAMP_SKEW_SECONDS + 1}`;
-      const { request, context } = signedDelivery('{}', { timestamp: ahead });
+      it('rejects a timestamp exactly one second beyond the future window', async () => {
+        const ahead = `${nowSeconds() + MAX_TIMESTAMP_SKEW_SECONDS + 1}`;
+        const { request, context } = signedDelivery('{}', { timestamp: ahead });
 
-      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+        expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+      });
+
+      it('reports the observed skew so clock drift is diagnosable', async () => {
+        const stale = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS - 42}`;
+        const { request, context } = signedDelivery('{}', { timestamp: stale });
+
+        await slackSignatureWrapper(next)(request, context);
+
+        const logged = log.warn.getCalls().map((c) => c.args.join(' ')).join('\n');
+        expect(logged).to.contain('reason=stale_timestamp');
+        expect(logged).to.contain(`skewSeconds=${MAX_TIMESTAMP_SKEW_SECONDS + 42}`);
+      });
     });
 
     it('rejects a body larger than the cap before hashing it', async () => {
@@ -313,6 +379,25 @@ describe('slackSignatureWrapper', () => {
       const { request, context } = signedDelivery(body);
 
       expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('rejects an oversized body whose content-length understates it (post-read enforcement)', async () => {
+      // The declared-length check is an honest-client hint; a forger can omit or understate it.
+      // This exercises the post-read byte-length branch the code calls "the real enforcement".
+      const body = 'x'.repeat(MAX_BODY_BYTES + 1);
+      const timestamp = `${nowSeconds()}`;
+      const headers = {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSlackSignature(SIGNING_SECRET, timestamp, body),
+      };
+      const request = buildRequest(body, { ...headers, 'content-length': '10' });
+
+      const result = await slackSignatureWrapper(next)(request, buildContext(headers));
+
+      expectUnauthorized(result);
+      const logged = log.warn.getCalls().map((c) => c.args.join(' ')).join('\n');
+      expect(logged).to.contain('reason=body_too_large');
+      expect(logged).to.contain('bodyBytes=');
     });
 
     it('rejects a declared-oversized content-length without reading the body', async () => {

--- a/test/support/slack/signature-wrapper.test.js
+++ b/test/support/slack/signature-wrapper.test.js
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import crypto from 'crypto';
+import { Request } from '@adobe/fetch';
+import bodyData from '@adobe/helix-shared-body-data/src/body-data-wrapper.js';
+import { use, expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import {
+  slackSignatureWrapper,
+  computeSlackSignature,
+  MAX_BODY_BYTES,
+  MAX_TIMESTAMP_SKEW_SECONDS,
+} from '../../../src/support/slack/signature-wrapper.js';
+
+use(sinonChai);
+
+const SIGNING_SECRET = 'test-signing-secret';
+
+describe('slackSignatureWrapper', () => {
+  let sandbox;
+  let log;
+  let next;
+
+  const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+  const buildRequest = (body, headers = {}) => new Request('https://spacecat.test/slack/events', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body,
+  });
+
+  const buildContext = (headers = {}, overrides = {}) => ({
+    log,
+    env: { SLACK_SIGNING_SECRET: SIGNING_SECRET },
+    pathInfo: { method: 'POST', suffix: '/slack/events', headers },
+    ...overrides,
+  });
+
+  // Mirrors what a genuine Slack delivery looks like: signed body + matching timestamp.
+  const signedDelivery = (body, { secret = SIGNING_SECRET, timestamp = `${nowSeconds()}` } = {}) => {
+    const headers = {
+      'x-slack-request-timestamp': timestamp,
+      'x-slack-signature': computeSlackSignature(secret, timestamp, body),
+    };
+    return { request: buildRequest(body, headers), context: buildContext(headers) };
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      debug: sandbox.stub(),
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+    };
+    next = sandbox.stub().resolves('downstream-called');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('routes it guards', () => {
+    it('passes a correctly signed request through to the downstream handler', async () => {
+      const body = JSON.stringify({ type: 'event_callback', event: { type: 'app_mention' } });
+      const { request, context } = signedDelivery(body);
+
+      const result = await slackSignatureWrapper(next)(request, context);
+
+      expect(result).to.equal('downstream-called');
+      expect(next).to.have.been.calledOnce;
+    });
+
+    it('verifies a form-urlencoded interactive payload byte-exactly', async () => {
+      // Slack posts interactive payloads as application/x-www-form-urlencoded and signs the
+      // encoded body, not the decoded JSON.
+      const body = `payload=${encodeURIComponent(JSON.stringify({ type: 'block_actions', actions: [{ action_id: 'approveOrg' }] }))}`;
+      const timestamp = `${nowSeconds()}`;
+      const headers = {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSlackSignature(SIGNING_SECRET, timestamp, body),
+      };
+      const request = new Request('https://spacecat.test/slack/events', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
+        body,
+      });
+
+      const result = await slackSignatureWrapper(next)(request, buildContext(headers));
+
+      expect(result).to.equal('downstream-called');
+    });
+
+    it('verifies a body containing multi-byte UTF-8 characters', async () => {
+      const body = JSON.stringify({ type: 'event_callback', text: 'héllo ☃ 日本語' });
+      const { request, context } = signedDelivery(body);
+
+      await slackSignatureWrapper(next)(request, context);
+
+      expect(next).to.have.been.calledOnce;
+    });
+
+    it('leaves non-Slack routes untouched, even with no signature headers', async () => {
+      const request = buildRequest('{}');
+      const context = buildContext({}, { pathInfo: { method: 'GET', suffix: '/sites', headers: {} } });
+
+      const result = await slackSignatureWrapper(next)(request, context);
+
+      expect(result).to.equal('downstream-called');
+      expect(log.warn).to.have.not.been.called;
+    });
+
+    it('guards the suffix form without a leading slash', async () => {
+      const request = buildRequest('{}');
+      const context = buildContext({}, { pathInfo: { method: 'POST', suffix: 'slack/events', headers: {} } });
+
+      const result = await slackSignatureWrapper(next)(request, context);
+
+      expect(result.status).to.equal(401);
+      expect(next).to.have.not.been.called;
+    });
+
+    it('tolerates a context with no pathInfo', async () => {
+      const result = await slackSignatureWrapper(next)(buildRequest('{}'), { log, env: {} });
+
+      expect(result).to.equal('downstream-called');
+    });
+  });
+
+  describe('rejects forged and malformed requests', () => {
+    const expectUnauthorized = (result) => {
+      expect(result.status).to.equal(401);
+      expect(result.headers.get('x-error')).to.equal('slack signature verification failed');
+      expect(next).to.have.not.been.called;
+    };
+
+    it('rejects a request with no signature headers at all (the VULN-39365 attack)', async () => {
+      const body = JSON.stringify({ type: 'event_callback', event: { type: 'app_mention' } });
+
+      const result = await slackSignatureWrapper(next)(buildRequest(body), buildContext({}));
+
+      expectUnauthorized(result);
+    });
+
+    it('rejects a signature computed with the wrong secret', async () => {
+      const body = JSON.stringify({ type: 'event_callback' });
+      const { request, context } = signedDelivery(body, { secret: 'attacker-guess' });
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('rejects when the body was tampered with after signing', async () => {
+      const timestamp = `${nowSeconds()}`;
+      const signedBody = JSON.stringify({ type: 'event_callback', event: { type: 'app_mention' } });
+      const headers = {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSlackSignature(SIGNING_SECRET, timestamp, signedBody),
+      };
+      const tamperedBody = JSON.stringify({ type: 'event_callback', event: { type: 'file_shared' } });
+
+      const result = await slackSignatureWrapper(next)(
+        buildRequest(tamperedBody, headers),
+        buildContext(headers),
+      );
+
+      expectUnauthorized(result);
+    });
+
+    it('rejects a missing timestamp header', async () => {
+      const body = '{}';
+      const headers = { 'x-slack-signature': computeSlackSignature(SIGNING_SECRET, `${nowSeconds()}`, body) };
+
+      expectUnauthorized(await slackSignatureWrapper(next)(
+        buildRequest(body, headers),
+        buildContext(headers),
+      ));
+    });
+
+    it('rejects a missing signature header', async () => {
+      const headers = { 'x-slack-request-timestamp': `${nowSeconds()}` };
+
+      expectUnauthorized(await slackSignatureWrapper(next)(
+        buildRequest('{}', headers),
+        buildContext(headers),
+      ));
+    });
+
+    it('rejects a malformed signature header without throwing on length mismatch', async () => {
+      const headers = {
+        'x-slack-request-timestamp': `${nowSeconds()}`,
+        'x-slack-signature': 'v0=not-hex',
+      };
+
+      expectUnauthorized(await slackSignatureWrapper(next)(
+        buildRequest('{}', headers),
+        buildContext(headers),
+      ));
+    });
+
+    it('rejects an uppercase-hex signature (pattern is strict)', async () => {
+      const body = '{}';
+      const timestamp = `${nowSeconds()}`;
+      const headers = {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSlackSignature(SIGNING_SECRET, timestamp, body).toUpperCase(),
+      };
+
+      expectUnauthorized(await slackSignatureWrapper(next)(
+        buildRequest(body, headers),
+        buildContext(headers),
+      ));
+    });
+
+    it('rejects a non-numeric timestamp', async () => {
+      const body = '{}';
+      const headers = {
+        'x-slack-request-timestamp': 'not-a-number',
+        'x-slack-signature': computeSlackSignature(SIGNING_SECRET, 'not-a-number', body),
+      };
+
+      expectUnauthorized(await slackSignatureWrapper(next)(
+        buildRequest(body, headers),
+        buildContext(headers),
+      ));
+    });
+
+    it('rejects a replayed request whose timestamp is too old', async () => {
+      const stale = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS - 1}`;
+      const { request, context } = signedDelivery('{}', { timestamp: stale });
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('rejects a timestamp too far in the future', async () => {
+      const future = `${nowSeconds() + MAX_TIMESTAMP_SKEW_SECONDS + 60}`;
+      const { request, context } = signedDelivery('{}', { timestamp: future });
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('accepts a timestamp at the edge of the replay window', async () => {
+      const edge = `${nowSeconds() - MAX_TIMESTAMP_SKEW_SECONDS + 2}`;
+      const { request, context } = signedDelivery('{}', { timestamp: edge });
+
+      const result = await slackSignatureWrapper(next)(request, context);
+
+      expect(result).to.equal('downstream-called');
+    });
+
+    it('rejects a body larger than the cap before hashing it', async () => {
+      const body = 'x'.repeat(MAX_BODY_BYTES + 1);
+      const { request, context } = signedDelivery(body);
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('rejects a declared-oversized content-length without reading the body', async () => {
+      const body = '{}';
+      const timestamp = `${nowSeconds()}`;
+      const headers = {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSlackSignature(SIGNING_SECRET, timestamp, body),
+      };
+      const request = buildRequest(body, { ...headers, 'content-length': `${MAX_BODY_BYTES + 1}` });
+      sandbox.spy(request, 'clone');
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, buildContext(headers)));
+      expect(request.clone).to.have.not.been.called;
+    });
+
+    it('fails closed when SLACK_SIGNING_SECRET is not configured', async () => {
+      const body = '{}';
+      const { request } = signedDelivery(body);
+      const timestamp = `${nowSeconds()}`;
+      const context = buildContext({
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': computeSlackSignature(SIGNING_SECRET, timestamp, body),
+      }, { env: {} });
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('fails closed when context.env is absent entirely', async () => {
+      const context = buildContext({}, { env: undefined });
+
+      expectUnauthorized(await slackSignatureWrapper(next)(buildRequest('{}'), context));
+    });
+
+    it('returns 401 rather than throwing when the body cannot be read', async () => {
+      const body = '{}';
+      const { request, context } = signedDelivery(body);
+      sandbox.stub(request, 'clone').throws(new Error('stream already consumed'));
+
+      expectUnauthorized(await slackSignatureWrapper(next)(request, context));
+    });
+
+    it('never logs the signature, secret or body', async () => {
+      const body = JSON.stringify({ secretish: 'do-not-log-me' });
+      const { request, context } = signedDelivery(body, { secret: 'attacker-guess' });
+
+      await slackSignatureWrapper(next)(request, context);
+
+      const logged = log.warn.getCalls().map((c) => c.args.join(' ')).join('\n');
+      expect(logged).to.contain('signature mismatch');
+      expect(logged).to.not.contain(SIGNING_SECRET);
+      expect(logged).to.not.contain('do-not-log-me');
+      expect(logged).to.not.contain('v0=');
+    });
+  });
+
+  describe('interaction with downstream body parsing', () => {
+    it('leaves the body readable by bodyData (uses clone, not the original stream)', async () => {
+      const payload = { type: 'event_callback', event: { type: 'app_mention', text: 'hi' } };
+      const body = JSON.stringify(payload);
+      const { request, context } = signedDelivery(body);
+
+      // bodyData is what actually populates context.data in the real chain, and it runs
+      // *after* this wrapper. Compose them the same way src/index.js does.
+      let parsed;
+      const chained = slackSignatureWrapper(bodyData(async (req, ctx) => {
+        parsed = ctx.data;
+        return 'ok';
+      }));
+
+      const result = await chained(request, context);
+
+      expect(result).to.equal('ok');
+      expect(parsed).to.deep.equal(payload);
+    });
+  });
+
+  describe('computeSlackSignature', () => {
+    it('matches the Slack-documented v0 basestring construction', async () => {
+      const timestamp = '1531420618';
+      const body = 'token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J';
+      const expected = `v0=${crypto
+        .createHmac('sha256', SIGNING_SECRET)
+        .update(`v0:${timestamp}:${body}`, 'utf8')
+        .digest('hex')}`;
+
+      expect(computeSlackSignature(SIGNING_SECRET, timestamp, body)).to.equal(expected);
+    });
+  });
+});

--- a/test/utils/slack/base.test.js
+++ b/test/utils/slack/base.test.js
@@ -415,7 +415,7 @@ describe('Base Slack Utils', () => {
   });
 
   describe('fetchFile', () => {
-    const baseUrl = 'https://fake-url.com';
+    const baseUrl = 'https://files.slack.com';
     const filePath = '/file.csv';
     const fileUrl = `${baseUrl}${filePath}`;
     const token = 'test-bot-token';
@@ -504,7 +504,7 @@ describe('Base Slack Utils', () => {
   });
 
   describe('parseCSV', () => {
-    const baseUrl = 'https://fake-url.com';
+    const baseUrl = 'https://files.slack.com';
     const filePath = '/file.csv';
     const fileUrl = `${baseUrl}${filePath}`;
     const token = 'test-bot-token';

--- a/test/utils/slack/file-url.test.js
+++ b/test/utils/slack/file-url.test.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import { isSlackFileUrl, assertSlackFileUrl } from '../../../src/utils/slack/file-url.js';
+
+describe('Slack file URL allowlist', () => {
+  describe('accepts Slack-owned https hosts', () => {
+    [
+      'https://files.slack.com/files-pri/T123-F456/report.csv',
+      'https://slack.com/files-pri/T123-F456/report.csv',
+      'https://adobe.enterprise.slack.com/files-pri/T1-F2/x.csv',
+      'https://FILES.SLACK.COM/files-pri/T1-F2/x.csv',
+    ].forEach((url) => {
+      it(`accepts ${url}`, () => {
+        expect(isSlackFileUrl(url)).to.be.true;
+      });
+    });
+  });
+
+  describe('rejects everything else', () => {
+    [
+      // The VULN-39365 primitive: an attacker-controlled host harvesting the bot token.
+      ['an attacker-controlled host', 'https://attacker.example.com/collect'],
+      // Userinfo trick -- the real authority is evil.test, not files.slack.com.
+      ['a userinfo-prefixed lookalike', 'https://files.slack.com@evil.test/collect'],
+      ['a userinfo+password lookalike', 'https://files.slack.com:token@evil.test/collect'],
+      // Suffix confusion -- these are NOT subdomains of slack.com.
+      ['a suffix-confusion domain', 'https://files.slack.com.evil.test/collect'],
+      ['a bare suffix-confusion domain', 'https://notslack.com/collect'],
+      ['a hyphenated lookalike', 'https://files-slack.com/collect'],
+      // Plaintext would put the bearer token on the wire.
+      ['plaintext http to Slack', 'http://files.slack.com/files-pri/T1-F2/x.csv'],
+      // SSRF against internal metadata / loopback.
+      ['AWS IMDS', 'https://169.254.169.254/latest/meta-data/'],
+      ['loopback', 'https://127.0.0.1/collect'],
+      // Non-http(s) schemes.
+      ['a file: URL', 'file:///etc/passwd'],
+      ['a data: URL', 'data:text/plain;base64,aGk='],
+      // Structurally invalid / absent input.
+      ['a relative URL', '/files-pri/T1-F2/x.csv'],
+      ['an empty string', ''],
+      ['undefined', undefined],
+      ['null', null],
+      ['a number', 42],
+      ['an object', { url: 'https://files.slack.com/x' }],
+    ].forEach(([label, url]) => {
+      it(`rejects ${label}`, () => {
+        expect(isSlackFileUrl(url)).to.be.false;
+      });
+    });
+  });
+
+  describe('assertSlackFileUrl', () => {
+    it('does not throw for a Slack-hosted URL', () => {
+      expect(() => assertSlackFileUrl('https://files.slack.com/files-pri/T1-F2/x.csv')).to.not.throw();
+    });
+
+    it('throws for a non-Slack URL', () => {
+      expect(() => assertSlackFileUrl('https://attacker.example.com/collect'))
+        .to.throw('Refusing to download file: URL is not a Slack-hosted https URL.');
+    });
+
+    it('does not leak the rejected URL into the error message', () => {
+      // The message reaches Slack and the logs; the URL is attacker-controlled.
+      try {
+        assertSlackFileUrl('https://attacker.example.com/collect?leak=secret');
+        expect.fail('expected assertSlackFileUrl to throw');
+      } catch (e) {
+        expect(e.message).to.not.contain('attacker.example.com');
+        expect(e.message).to.not.contain('leak=secret');
+      }
+    });
+  });
+});

--- a/test/utils/slack/file-url.test.js
+++ b/test/utils/slack/file-url.test.js
@@ -47,6 +47,11 @@ describe('Slack file URL allowlist', () => {
       // Non-http(s) schemes.
       ['a file: URL', 'file:///etc/passwd'],
       ['a data: URL', 'data:text/plain;base64,aGk='],
+      // Trailing dot is the FQDN root form: 'files.slack.com.' does not end with '.slack.com'
+      // and is not in the exact-match set, so it is rejected. Pinned because a future
+      // normalisation change could silently make it pass.
+      ['a trailing-dot FQDN host', 'https://files.slack.com./files-pri/T1-F2/x.csv'],
+      ['a trailing-dot bare host', 'https://slack.com./collect'],
       // Structurally invalid / absent input.
       ['a relative URL', '/files-pri/T1-F2/x.csv'],
       ['an empty string', ''],


### PR DESCRIPTION
Fixes the Slack integration to authenticate inbound requests. Details of the underlying
report are in **VULN-39365** (Jira) — deliberately not restated here, as this is a public
repository and the fix is not yet deployed.

## Problem

`/slack/events` was not verifying that a request actually came from Slack:

- `POST|GET /slack/events` is in `ANONYMOUS_ENDPOINTS` in spacecat-shared's `authWrapper`,
  so the authentication manager never runs for it.
- Bolt's signature check lives in its **HTTP receiver**, which this service bypasses by
  calling `app.processEvent({ body, ack })` on an already-parsed body. The `signingSecret`
  passed to `new App(...)` in `src/controllers/slack.js` was therefore configured but never
  exercised.

Net effect: any unauthenticated caller could reach every registered Slack command, action
and view handler with a payload of their choosing.

## Fix

**1. `slackSignatureWrapper` (`src/support/slack/signature-wrapper.js`)** — verifies Slack's
v0 HMAC-SHA256 signature over the raw body plus a ±5 minute timestamp window, with a
timing-safe compare.

Placement is the load-bearing detail. It is declared immediately before `enrichPathInfo` in
the `.with()` chain, which (helix-shared-wrap runs the last `.with()` outermost) puts it
directly **after** `enrichPathInfo` — so `pathInfo.headers` is populated — and **before**
`multipartFormData`/`bodyData`, so the body is still unread. Verified execution order:

```
enrichPathInfo -> slackSignatureWrapper -> multipartFormData -> bodyData
```

It reads the body via `request.clone().text()`, never `request.text()`, because `bodyData`
consumes the body downstream. A test asserts `context.data` is still populated afterwards.

Fails closed on every path: missing, malformed, stale, future-dated, oversized or
mismatching input, **and** on a missing `SLACK_SIGNING_SECRET`. Bodies over 1 MiB are
rejected before any HMAC work (pre-auth exhaustion guard, mirroring
`github-webhook-hmac-handler.js`).

**2. Slack file-host allowlist (`src/utils/slack/file-url.js`)** — defence in depth. Two
call sites attach the bot token to an outbound fetch of a payload-supplied URL
(`utils/slack/base.js#fetchFile`, `slack/commands/toggle-site-audit.js`). Both now require a
Slack-owned https host first. Note `support/url-safety.js#isSafeDomain` is a *denylist* of
private ranges and does not stop an attacker-controlled public host, so a positive allowlist
is required here.

**3. `GET /slack/events` removed** — Slack only ever POSTs, and a GET carries no body to
sign, so it could never be verified. Removed from `routes/index.js`,
`required-capabilities.js` and `facs-capabilities.js` (the route-drift guards caught the
last two).

## Testing

- 25 new tests for the wrapper: valid pass-through (JSON, form-urlencoded, multi-byte
  UTF-8), forged/absent/malformed signature, tampered body, replay window edges, oversized
  body, missing secret, unreadable body, non-Slack route pass-through, and a check that
  nothing sensitive is logged.
- 24 new tests for the allowlist, including userinfo (`https://files.slack.com@evil.test/`)
  and suffix-confusion (`files.slack.com.evil.test`) bypasses.
- Test fixtures that pointed `url_private` at `example.com` now use `files.slack.com`, which
  is what Slack actually sends.
- Full suite: **18152 passing, 0 failing**. Lint, `type-check:base` and `type-check:strict`
  all clean.

## Deploy notes

⚠️ **`SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` must be rotated in Vault.** The report
shows the token was used against internal channels, so it is compromised independently of
this fix. Rotating the signing secret is safe with this change deployed (the wrapper reads
it per request from `context.env`).

**Fastly header pass-through: verified.** Checked the VCL for service `DlxppS2VoAizEqJ9bPasq6`
(`spacecat-infrastructure/fastly/vcl/aso-prod/`). The only `unset req.http.*` in the whole
service is `X-Spacecat-Cross-Product-Context` (anti-spoofing on an internal header) — there is
no header allowlist and no stripping of client headers, so `X-Slack-Signature` and
`X-Slack-Request-Timestamp` reach the origin intact. Nothing in the VCL mutates the request
body (which would otherwise break the HMAC), and `recv/200` does `return(pass)` for this path,
so Slack traffic bypasses caching entirely. Caveat: that VCL is a backup last synced
2026-07-30 (aso-prod v120), so a live re-check is cheap insurance.

Still worth watching 401s on `POST /slack/events` immediately after deploy.

Depends on / related: adobe/spacecat-shared#1920

## Review follow-ups

A multi-persona review (architect / security / DBA / tester agents, run independently against
the full diff) produced no Critical findings and no bypass of the signature check or the file
allowlist. Six Major findings were raised and **all six are fixed in this PR** — the notable
ones: a third anonymous-route registry (`AccessControlUtil`) still listed the removed `GET`
route; `OPTIONS` preflight was being turned into a 401; and there was no test proving the
wrapper is actually *wired into* `main` (a mis-ordered wrapper would have shipped green).

Two findings are **deliberately deferred**, tracked, and should inform the merge decision:

| Ticket | Finding | Why not here |
|---|---|---|
| [SITES-51204](https://jira.corp.adobe.com/browse/SITES-51204) | **Signature ≠ authorization.** Any Slack workspace user who can see an approval button can still trigger `approveOrg` and reassign a site's IMS org (`approve-org.js:34-51` uses `body.user` only for the reply text). | Choosing a policy (named approver / admin-only / usergroup) is a product decision; guessing risks breaking the ops team's daily Slack workflow. This PR still reduces the population from *the entire internet, unauthenticated* to *your Slack workspace*. |
| [SITES-51205](https://jira.corp.adobe.com/browse/SITES-51205) | **Replay within the 5-minute window** can repeat non-idempotent writes (`set-live-status` toggles rather than setting a target state). | Pre-existing, not a regression; replay now requires capturing a genuinely signed request. Needs a durable TTL'd store — too much to land unreviewed in a blocker. |

The ±300s window matches Slack's own Bolt SDK (`@slack/bolt/dist/receivers/verify-request.js`,
`requestTimestampMaxDeltaMin = 5`), and is stricter in two ways: it also rejects future-dated
timestamps, and its `/^\d+$/` check is effective where Bolt's `Number.isNaN(string)` guard is not.

Also noted for incident response (pre-existing, not introduced here): `approveOrg` does not call
`reparentSiteProject`, so a pre-fix forged call could have left a site whose `organizationId`
differs from its project's. Worth auditing for that mismatch.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: multi-repo
relatedPRs: ["adobe/spacecat-shared#1920"]
rationale: "Adds Slack request-signature verification to a previously unauthenticated endpoint, plus a file-host allowlist. Fails closed and only ever restricts access, so it cannot widen exposure. The realistic failure mode is over-rejection, which would break the internal SpaceCat Slack bot -- internal ops tooling, no customer-facing surface -- and is immediately reversible by redeploying the previous release. No schema or data operation, no external API contract change."
recommendations: "Rotate SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET in Vault (required, independent of this fix). Fastly header pass-through verified against the aso-prod VCL (no header stripping, no body mutation). Watch 401 rate on POST /slack/events after deploy."
backout: "Redeploy the previous release; no data migration or state change to unwind."
```


