### PR TITLE
fix(serenity): brand-scope topic prompts and topics with CBF_brand | LLMO-7443

### DIFF
--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -509,6 +509,35 @@ async function authorizeBrandSubWorkspace(ctx, log) {
   return { workspaceId, brandUuid, brand };
 }
 
+/**
+ * Resolves the `CBF_brand` value for a brand-scoped element call.
+ *
+ * Returns the brand's trimmed display name, or `undefined` when it has none — in which
+ * case the element falls back to brand-agnostic counts (any tracked brand in the
+ * response), which is the pre-LLMO-7443 behavior and inflates the numbers. That fallback
+ * is deliberate (a data-quality gap degrades a metric rather than 500-ing a dashboard),
+ * so it is logged rather than raised.
+ *
+ * The trim is what keeps the warning honest: `hasText` is `!!str && isString(str)` and
+ * does NOT trim, so a whitespace-only name is "text" by that test while being useless as
+ * a filter value. Deriving both the log decision and the emitted value from the same
+ * trimmed string means the log can never claim a brand-agnostic fallback while the
+ * payload actually carries a garbage `CBF_brand` (and vice versa).
+ *
+ * @param {object} [brand] - Brand identity (`{ id, name }`) from authorizeBrandSubWorkspace.
+ * @param {object} log - Logger.
+ * @param {string} route - Handler name, for the warning.
+ * @returns {string|undefined} Trimmed brand name, or undefined when unusable.
+ */
+function resolveBrandFilterName(brand, log, route) {
+  const name = typeof brand?.name === 'string' ? brand.name.trim() : '';
+  if (!name) {
+    log.warn(`elements: brand has no display name - ${route} falls back to brand-agnostic counts`, { brandId: brand?.id });
+    return undefined;
+  }
+  return name;
+}
+
 export default function ElementsController(context, log, env) {
   if (!isNonEmptyObject(context)) {
     throw new Error('Context required');
@@ -1183,19 +1212,13 @@ export default function ElementsController(context, log, env) {
       }
 
       // Brand-scope the element to this brand's mentions (CBF_brand); without it the
-      // per-topic aggregates count any tracked brand in the topic's responses. A brand
-      // with no display name falls back to the old brand-agnostic (inflated) counts —
-      // warn so that is traceable rather than silent.
-      if (!hasText(brand?.name)) {
-        log.warn('elements: brand has no display name - listTopics falls back to brand-agnostic counts', { brandId });
-      }
-
+      // per-topic aggregates count any tracked brand in the topic's responses.
       const topics = await service.getTopics(workspaceId, {
         model: query.model || query.platform,
         startDate: hasText(startDate) ? startDate : undefined,
         endDate: hasText(endDate) ? endDate : undefined,
         projectIds,
-        brandName: brand?.name,
+        brandName: resolveBrandFilterName(brand, log, 'listTopics'),
       });
 
       return cachedOk({ topics, totalCount: topics.length });
@@ -1275,19 +1298,14 @@ export default function ElementsController(context, log, env) {
       }
 
       // Brand-scope the element to this brand's mentions (CBF_brand); see the payload
-      // builder's header for why the sub-workspace alone is not sufficient. A brand with
-      // no display name falls back to brand-agnostic counts — warn rather than fail.
-      if (!hasText(brand?.name)) {
-        log.warn('elements: brand has no display name - listTopicPrompts falls back to brand-agnostic counts', { brandId });
-      }
-
+      // builder's header for why the sub-workspace alone is not sufficient.
       const allPrompts = await service.getTopicPrompts(workspaceId, {
         topic,
         model: query.model || query.platform,
         startDate: hasText(startDate) ? startDate : undefined,
         endDate: hasText(endDate) ? endDate : undefined,
         projectIds,
-        brandName: brand?.name,
+        brandName: resolveBrandFilterName(brand, log, 'listTopicPrompts'),
       });
 
       // Client-side pagination (mirrors listOwnedUrls); totalCount is the full count.

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -17,7 +17,6 @@ import { hasText, isNonEmptyObject, isValidUUID } from '@adobe/spacecat-shared-u
 import { cleanupHeaderValue } from '@adobe/helix-shared-utils';
 
 import { getBrandIdentity, getBrandBySite } from '../support/brands-storage.js';
-import { resolveBrandUuid } from '../support/prompts-storage.js';
 import { createElementsTransport } from '../support/elements/elements-transport.js';
 import { ElementsTransportError } from '../support/elements/errors.js';
 import { createElementsService } from '../support/elements/elements-service.js';
@@ -434,11 +433,14 @@ async function authorizeOrg(ctx) {
  *
  * @param {object} ctx - Request context.
  * @param {object} log - Logger (for the misconfiguration alert).
- * @returns {Promise<{workspaceId: string, brandUuid: string} | {error: Response}>}
- *   the brand's sub-workspace id and resolved Postgres brand UUID on success, or a
+ * @returns {Promise<{workspaceId: string, brandUuid: string, brand: object} | {error: Response}>}
+ *   the brand's sub-workspace id, resolved Postgres brand UUID and brand identity
+ *   (`{ id, name }`) on success, or a
  *   Response on failure (400 non-UUID brandId, 403 no access, 404 org/brand not found
  *   or brand has no sub-workspace, 409 sub-workspace misconfigured as the parent).
- *   `brandUuid` lets callers run the project-ownership guard (see listUrlPrompts).
+ *   `brandUuid` lets callers run the project-ownership guard (see listUrlPrompts);
+ *   `brand.name` is the `CBF_brand` value used to brand-scope elements that are not
+ *   scoped by the sub-workspace alone (see topic-prompts.js).
  */
 async function authorizeBrandSubWorkspace(ctx, log) {
   const spaceCatId = ctx?.params?.spaceCatId;
@@ -454,7 +456,12 @@ async function authorizeBrandSubWorkspace(ctx, log) {
   if (!postgrestClient?.from) {
     return { error: createResponse({ error: 'configurationError', message: 'PostgREST client not available' }, 503) };
   }
-  const brandUuid = await resolveBrandUuid(spaceCatId, brandId, postgrestClient);
+  // getBrandIdentity (rather than resolveBrandUuid) so callers also get the brand's
+  // display NAME for `CBF_brand` scoping. Equivalent lookup here: the non-UUID brandId
+  // path is already rejected above, so resolveBrandUuid's name-ilike fallback is
+  // unreachable and both resolve `brands` by organization_id + id.
+  const brand = await getBrandIdentity(spaceCatId, brandId, postgrestClient);
+  const brandUuid = brand?.id;
   if (!brandUuid) {
     return { error: notFound(`Brand not found for organization: ${brandId}`) };
   }
@@ -499,7 +506,7 @@ async function authorizeBrandSubWorkspace(ctx, log) {
       ),
     };
   }
-  return { workspaceId, brandUuid };
+  return { workspaceId, brandUuid, brand };
 }
 
 export default function ElementsController(context, log, env) {
@@ -1126,7 +1133,9 @@ export default function ElementsController(context, log, env) {
    * (78864493) fetched across ALL topics, grouped by topic and aggregated
    * server-side (promptCount, brandMentions/citations, avg visibility/position/sentiment).
    *
-   * Brand-scoped via the brand's Semrush **sub-workspace** (like {@link listTopicPrompts}).
+   * Brand-scoped by the brand's Semrush **sub-workspace** AND a `CBF_brand` filter on the
+   * brand's display name (like {@link listTopicPrompts}) — the sub-workspace alone leaves
+   * competitor mentions in the counts, see topic-prompts.js.
    * Caller-supplied projectId(s) (optional) scope to `CBF_project`; absent → all of the
    * brand's markets.
    * Returns the full topic list (`{ topics, totalCount }`); the table paginates client-side.
@@ -1142,7 +1151,7 @@ export default function ElementsController(context, log, env) {
         return auth.error;
       }
       const { brandId } = ctx?.params ?? {};
-      const { workspaceId } = auth;
+      const { workspaceId, brand } = auth;
       const query = extractQuery(ctx);
 
       // Date range is optional; when present it must be a valid, ordered YYYY-MM-DD pair.
@@ -1173,11 +1182,20 @@ export default function ElementsController(context, log, env) {
         return ownershipError;
       }
 
+      // Brand-scope the element to this brand's mentions (CBF_brand); without it the
+      // per-topic aggregates count any tracked brand in the topic's responses. A brand
+      // with no display name falls back to the old brand-agnostic (inflated) counts —
+      // warn so that is traceable rather than silent.
+      if (!hasText(brand?.name)) {
+        log.warn('elements: brand has no display name - listTopics falls back to brand-agnostic counts', { brandId });
+      }
+
       const topics = await service.getTopics(workspaceId, {
         model: query.model || query.platform,
         startDate: hasText(startDate) ? startDate : undefined,
         endDate: hasText(endDate) ? endDate : undefined,
         projectIds,
+        brandName: brand?.name,
       });
 
       return cachedOk({ topics, totalCount: topics.length });
@@ -1193,8 +1211,11 @@ export default function ElementsController(context, log, env) {
    * PROMPTS_BY_TOPIC element (78864493), scoped by `CBF_topic` = the topic NAME
    * (`:topicId` is the URL-encoded topic name, not a UUID — Semrush topics have no id).
    *
-   * Brand-scoped via the brand's Semrush **sub-workspace** (like {@link listPrompts} —
-   * projects/prompts live only there). Caller-supplied projectId(s) (optional) scope
+   * Brand-scoped by the brand's Semrush **sub-workspace** (like {@link listPrompts} —
+   * projects/prompts live only there) AND by a `CBF_brand` filter on the brand's display
+   * name: without the latter the element counts ANY tracked brand mentioned in the topic's
+   * responses, so competitors inflate mentions/visibility/citations (see topic-prompts.js).
+   * Caller-supplied projectId(s) (optional) scope
    * to `CBF_project`; absent → all of the brand's markets. Pagination is
    * client-side (Semrush has no server-side paging); `totalCount` is the full count.
    *
@@ -1210,7 +1231,7 @@ export default function ElementsController(context, log, env) {
         return auth.error;
       }
       const { brandId, topicId } = ctx?.params ?? {};
-      const { workspaceId } = auth;
+      const { workspaceId, brand } = auth;
 
       // :topicId is the URL-encoded topic NAME. enrichPathInfo already decodes path
       // params, but decode defensively in case a caller double-encodes.
@@ -1253,12 +1274,20 @@ export default function ElementsController(context, log, env) {
         return ownershipError;
       }
 
+      // Brand-scope the element to this brand's mentions (CBF_brand); see the payload
+      // builder's header for why the sub-workspace alone is not sufficient. A brand with
+      // no display name falls back to brand-agnostic counts — warn rather than fail.
+      if (!hasText(brand?.name)) {
+        log.warn('elements: brand has no display name - listTopicPrompts falls back to brand-agnostic counts', { brandId });
+      }
+
       const allPrompts = await service.getTopicPrompts(workspaceId, {
         topic,
         model: query.model || query.platform,
         startDate: hasText(startDate) ? startDate : undefined,
         endDate: hasText(endDate) ? endDate : undefined,
         projectIds,
+        brandName: brand?.name,
       });
 
       // Client-side pagination (mirrors listOwnedUrls); totalCount is the full count.
@@ -1284,7 +1313,8 @@ export default function ElementsController(context, log, env) {
    *
    * Brand-scoped via the brand's Semrush **sub-workspace** (like {@link listTopicPrompts});
    * the brand is NOT sent as a filter (`CBF_brand` is redundant with sub-workspace scoping —
-   * see url-prompts.js). Pagination is client-side; `totalCount` is the full count.
+   * see url-prompts.js; note that premise proved FALSE for the topics elements above).
+   * Pagination is client-side; `totalCount` is the full count.
    *
    * Query params: `url` (required, the cited URL), `startDate`/`endDate` (required,
    * YYYY-MM-DD), `model`/`platform` (optional, default search-gpt), `projectId`

--- a/src/support/elements/definitions/sentiment-overview.js
+++ b/src/support/elements/definitions/sentiment-overview.js
@@ -64,6 +64,8 @@ function defaultDateRange() {
  *  - Brand scoping comes from the request targeting the brand's sub-workspace (resolved in
  *    the controller); the MFE also passes `CBF_brand` (name), but the sub-workspace already
  *    scopes to the brand, so we don't duplicate it here.
+ *    CAVEAT: that premise was DISPROVEN live for PROMPTS_BY_TOPIC (see topic-prompts.js);
+ *    it is UNVERIFIED for this element and deserves its own MFE reconciliation.
  *
  * @param {object} [params]
  * @param {string} [params.model] - AI model filter value (Semrush engine name or UI

--- a/src/support/elements/definitions/topic-prompts.js
+++ b/src/support/elements/definitions/topic-prompts.js
@@ -43,6 +43,11 @@ import { resolveElementModel } from '../constants.js';
  *    counts ANY tracked brand appearing in the topic's responses, so competitor mentions
  *    inflate the brand's mentions/visibility/citations. The column is `CBF_brand`, NOT
  *    `CBF_ws_brand`. `CBF_brand_urls` remains un-sent (it scopes URL lists, not mentions).
+ *  - `CBF_brand` is an ATTRIBUTION filter, not a row filter: it changes each row's
+ *    mentions/citations/visibility but never the row set. Verified twice — an all-topics
+ *    probe returned the same 1520 rows with and without it, and the case/alias probe
+ *    returned an identical 45-row set for a matching name, a non-matching name and an
+ *    alias. So `totalCount`, `promptCount` and pagination are unaffected by brand scoping.
  */
 
 /**
@@ -72,9 +77,16 @@ function toNumberOrNull(value) {
  * @param {string[]} [params.projectIds] - Multiple Semrush project ids to OR together
  *   (`CBF_project`); takes precedence over `projectId` when both are given.
  * @param {string} [params.brandName] - Brand display name to scope mentions/visibility/
- *   citations to this brand (`CBF_brand`). Omitted → brand-agnostic (counts any tracked
- *   brand in the topic's responses). Sent as the brand's display name; exact-name matching
- *   is what the live probe covered — whether Semrush also resolves aliases is [unverified].
+ *   citations to this brand (`CBF_brand`). Omitted, blank or whitespace-only →
+ *   brand-agnostic (counts any tracked brand in the topic's responses).
+ *   VERIFIED live 2026-09-08 (Lovesac, topic "Lovesac Furniture and Accessories",
+ *   2026-08-17..2026-08-23): matching is **exact and CASE-SENSITIVE**, and registered
+ *   aliases are **NOT** resolved — `Lovesac` → 315 mentions, while `lovesac` → 0 and the
+ *   registered alias `PillowSac` → 0, over an identical 45-row set. So this value must be
+ *   the brand's exact Semrush-tracked name: any casing/rename/alias divergence between
+ *   `brands.name` and Semrush silently zeroes the counts, which is indistinguishable from
+ *   a genuine "no presence". That is why a blank name falls back to brand-agnostic rather
+ *   than sending a value that cannot match.
  * @returns {object} Semrush element request payload.
  */
 export function buildTopicPromptsPayload({
@@ -91,8 +103,15 @@ export function buildTopicPromptsPayload({
   // (verified live against the Brand Presence MFE, which sends this filter — see the
   // module header). Wrapped in a single-value `or` block to match the CBF_model/
   // CBF_topic/CBF_project shape below; functionally identical to the MFE's bare `eq`.
-  if (brandName) {
-    advancedFilters.push({ op: 'or', filters: [{ op: 'eq', val: brandName, col: 'CBF_brand' }] });
+  //
+  // Trimmed here, and treated as absent when the result is empty, so the invariant holds
+  // for EVERY caller: a blank or whitespace-only name must fall back to brand-agnostic
+  // rather than send `CBF_brand: "   "`, which matches no brand and would silently zero
+  // the counts — indistinguishable from a real "no presence". Note `hasText` does NOT
+  // trim (`!!str && isString(str)`), so guarding with it here would not catch "   ".
+  const scopedBrand = typeof brandName === 'string' ? brandName.trim() : '';
+  if (scopedBrand) {
+    advancedFilters.push({ op: 'or', filters: [{ op: 'eq', val: scopedBrand, col: 'CBF_brand' }] });
   }
   // Topic scoping: the bare topic name on CBF_topic (verified live). Absent → all topics.
   if (topic) {

--- a/src/support/elements/definitions/topic-prompts.js
+++ b/src/support/elements/definitions/topic-prompts.js
@@ -33,9 +33,16 @@ import { resolveElementModel } from '../constants.js';
  *  - Date range → `filters.simple.start_date`/`end_date` (YYYY-MM-DD) when provided;
  *    omitted → the element applies its own default window.
  *  - `comparison_data_formatting: 'join'` matches the live MFE (NOT 'union').
- *  - Brand scoping comes from targeting the brand's sub-workspace (resolved in the
- *    controller), so `CBF_brand`/`CBF_brand_urls` (which the MFE also sends) are not
- *    duplicated here.
+ *  - Brand scoping needs `CBF_brand` (the brand display name) — the sub-workspace ALONE
+ *    is NOT enough. This file previously claimed the opposite ("the sub-workspace already
+ *    scopes the brand, so CBF_brand is not duplicated here"); that premise is FALSE for
+ *    this element and was disproven live: topic "3 ft Bean Bag" (Lovesac, chatgpt,
+ *    2026-08-17..2026-08-23) scored visibility 14.29 / mentions 1 off a ChatGPT answer
+ *    that named Pottery Barn and never mentioned Lovesac, while the Brand Presence MFE —
+ *    which DOES send `CBF_brand` — correctly showed 0. Without the filter the element
+ *    counts ANY tracked brand appearing in the topic's responses, so competitor mentions
+ *    inflate the brand's mentions/visibility/citations. The column is `CBF_brand`, NOT
+ *    `CBF_ws_brand`. `CBF_brand_urls` remains un-sent (it scopes URL lists, not mentions).
  */
 
 /**
@@ -64,16 +71,29 @@ function toNumberOrNull(value) {
  * @param {string} [params.projectId] - Single Semrush project id to scope to (`CBF_project`).
  * @param {string[]} [params.projectIds] - Multiple Semrush project ids to OR together
  *   (`CBF_project`); takes precedence over `projectId` when both are given.
+ * @param {string} [params.brandName] - Brand display name to scope mentions/visibility/
+ *   citations to this brand (`CBF_brand`). Omitted → brand-agnostic (counts any tracked
+ *   brand in the topic's responses). Sent as the brand's display name; exact-name matching
+ *   is what the live probe covered — whether Semrush also resolves aliases is [unverified].
  * @returns {object} Semrush element request payload.
  */
 export function buildTopicPromptsPayload({
-  topic, model, platform, startDate, endDate, projectId, projectIds,
+  topic, model, platform, startDate, endDate, projectId, projectIds, brandName,
 } = {}) {
   const resolvedModel = resolveElementModel(model || platform);
 
   const advancedFilters = [
     { op: 'or', filters: [{ op: 'eq', val: resolvedModel, col: 'CBF_model' }] },
   ];
+  // Brand scoping: restrict mentions/visibility/citations to THIS brand via CBF_brand.
+  // Without it the element counts ANY tracked brand in the topic's responses, so a
+  // competitor mentioned in an answer where the brand is absent inflates the numbers
+  // (verified live against the Brand Presence MFE, which sends this filter — see the
+  // module header). Wrapped in a single-value `or` block to match the CBF_model/
+  // CBF_topic/CBF_project shape below; functionally identical to the MFE's bare `eq`.
+  if (brandName) {
+    advancedFilters.push({ op: 'or', filters: [{ op: 'eq', val: brandName, col: 'CBF_brand' }] });
+  }
   // Topic scoping: the bare topic name on CBF_topic (verified live). Absent → all topics.
   if (topic) {
     advancedFilters.push({ op: 'or', filters: [{ op: 'eq', val: topic, col: 'CBF_topic' }] });

--- a/src/support/elements/definitions/url-prompts.js
+++ b/src/support/elements/definitions/url-prompts.js
@@ -35,6 +35,10 @@ import { resolveElementModel, isAllPlatforms } from '../constants.js';
  *    controller). The live MFE also sends `CBF_brand`, but the url-inspector sibling
  *    definitions (owned-urls / domain-urls / cited-domains) do not duplicate it —
  *    the sub-workspace already scopes the brand — so it is omitted here too.
+ *    CAVEAT: this shared "sub-workspace makes CBF_brand redundant" premise was DISPROVEN
+ *    live for PROMPTS_BY_TOPIC (see topic-prompts.js — competitor mentions inflated the
+ *    brand's numbers until CBF_brand was added). It is UNVERIFIED for this element; worth
+ *    re-checking against the MFE before trusting the counts here.
  *  - Market scope → the element's TOP-LEVEL `project_id` (like owned-urls), NOT a
  *    `CBF_project` advanced filter (verified live 2026-07-30: `CBF_project` is a silent
  *    no-op; a bogus top-level `project_id` → HTTP 422). The element takes ONE project id

--- a/src/support/elements/element-ids.js
+++ b/src/support/elements/element-ids.js
@@ -84,7 +84,8 @@ export const ELEMENT_IDS = Object.freeze({
   //     closest_date, url_cbf }.
   // Scoped by `CBF_source` = the full URL string (placed in BOTH simple and
   // advanced — unique to this element) + date (`CBF_date__start`/`__end`) +
-  // `CBF_model`. Brand scoping is via the sub-workspace (no CBF_brand filter).
+  // `CBF_model`. Brand scoping is via the sub-workspace (no CBF_brand filter) —
+  // premise DISPROVEN for PROMPTS_BY_TOPIC (see topic-prompts.js), unverified here.
   // Does NOT return category/topic/region. Verified live 2026-07-29.
   URL_PROMPTS: 'b4f1ead7-4aea-41ea-b1ce-311004715d63',
 

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -630,7 +630,9 @@ export function createElementsService(transport, log) {
      * is applied client-side by the controller (Semrush has no server-side paging).
      *
      * @param {string} workspaceId - Semrush sub-workspace UUID (projects/prompts live here).
-     * @param {object} params - Query params (topic, model/platform, startDate, endDate, projectId).
+     * @param {object} params - Query params (topic, model/platform, startDate, endDate,
+     *   projectId, brandName). `brandName` → `CBF_brand`; omit only to deliberately count
+     *   every tracked brand (see buildTopicPromptsPayload).
      * @returns {Promise<Array<object>>} Per-prompt rows (see transformTopicPromptsResponse).
      */
     /* c8 ignore start -- LLMO-6418 POC endpoint; unit tests intentionally deferred */
@@ -712,7 +714,9 @@ export function createElementsService(transport, log) {
      * Single upstream call; no fan-out.
      *
      * @param {string} workspaceId - Semrush sub-workspace UUID.
-     * @param {object} params - Query params (model/platform, startDate, endDate, projectId).
+     * @param {object} params - Query params (model/platform, startDate, endDate, projectId,
+     *   brandName). `brandName` → `CBF_brand`, same brand-scoping contract as
+     *   {@link getTopicPrompts}.
      * @returns {Promise<Array<object>>} Per-topic aggregate rows.
      */
     /* c8 ignore start -- LLMO-6418 POC endpoint; unit tests intentionally deferred */

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -199,14 +199,12 @@ describe('ElementsController', () => {
   let createElementsServiceStub;
   let createElementsTransportStub;
   let exchangePromiseTokenStub;
-  let resolveBrandUuidStub;
   let MockElementsTransportError;
   let getWorkspaceResourcesStub;
   let createSerenityTransportStub;
   let ElementsController;
 
   beforeEach(async () => {
-    resolveBrandUuidStub = sinon.stub().resolves(BRAND_ID);
     resolveBrandWorkspaceStub = sinon.stub().resolves({
       mode: 'subworkspace', workspaceId: SUB_WORKSPACE_ID, parentWorkspaceId: WORKSPACE_ID,
     });
@@ -265,9 +263,6 @@ describe('ElementsController', () => {
       '../../src/support/brands-storage.js': {
         getBrandIdentity: getBrandIdentityStub,
         getBrandBySite: getBrandBySiteStub,
-      },
-      '../../src/support/prompts-storage.js': {
-        resolveBrandUuid: resolveBrandUuidStub,
       },
       '../../src/support/serenity/workspace-resolver.js': {
         resolveBrandWorkspace: resolveBrandWorkspaceStub,

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -224,6 +224,8 @@ describe('ElementsController', () => {
       getUrlInspectorStats: sinon.stub().resolves(URL_INSPECTOR_STATS_RESULT),
       getDomainUrls: sinon.stub().resolves({ urls: [], totalCount: 0 }),
       getOwnedUrlProjects: sinon.stub().resolves([{ region: 'US', projectId: 'proj-1' }]),
+      getTopics: sinon.stub().resolves([]),
+      getTopicPrompts: sinon.stub().resolves([]),
     };
     createElementsServiceStub = sinon.stub().returns(serviceStub);
     createElementsTransportStub = sinon.stub().returns({ fetchElement: sinon.stub() });
@@ -1962,6 +1964,56 @@ describe('ElementsController', () => {
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       const res = await ctrl.getUrlInspectorPromptsCount(ctx);
       expect(res.status).to.equal(502);
+    });
+  });
+
+  // ─── listTopics / listTopicPrompts brand scoping (LLMO-7443) ──────────────
+  describe('listTopics / listTopicPrompts brand scoping', () => {
+    const TOPIC = '3 ft Bean Bag';
+    const topicsUrl = (qs = '') => `https://api.example.com/v2/orgs/${ORG_ID}`
+      + `/brands/${BRAND_ID}/serenity/brand-presence/topics${qs}`;
+    const promptsUrlForTopic = (qs = '') => `https://api.example.com/v2/orgs/${ORG_ID}`
+      + `/brands/${BRAND_ID}/serenity/brand-presence/topics/${encodeURIComponent(TOPIC)}/prompts${qs}`;
+
+    const topicsCtx = (overrides = {}) => fakeContext({
+      url: topicsUrl(),
+      withBrandSemrushProject: true,
+      brandSemrushProjects: [makeBrandSemrushProject({ getSemrushProjectId: () => 'proj-1' })],
+      ...overrides,
+    });
+
+    it('passes the brand display name to getTopics as brandName (CBF_brand)', async () => {
+      const ctx = topicsCtx();
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      await ctrl.listTopics(ctx);
+      const [, params] = serviceStub.getTopics.firstCall.args;
+      expect(params.brandName).to.equal('Adobe Brand');
+    });
+
+    it('passes the brand display name to getTopicPrompts as brandName (CBF_brand)', async () => {
+      const ctx = topicsCtx({
+        url: promptsUrlForTopic(),
+        params: { topicId: encodeURIComponent(TOPIC) },
+      });
+      const ctrl = ElementsController(ctx, fakeLog(), ENV);
+      await ctrl.listTopicPrompts(ctx);
+      const [, params] = serviceStub.getTopicPrompts.firstCall.args;
+      expect(params.brandName).to.equal('Adobe Brand');
+    });
+
+    // Fail-open: a brand with no usable display name must degrade to brand-agnostic
+    // counts rather than send a garbage CBF_brand, and must say so in the log.
+    // `hasText` does not trim, so whitespace-only is the case that would slip through
+    // a naive guard — assert it explicitly.
+    it('omits brandName and warns when the brand name is whitespace-only', async () => {
+      getBrandIdentityStub.resolves({ id: BRAND_ID, name: '   ' });
+      const log = fakeLog();
+      const ctx = topicsCtx();
+      const ctrl = ElementsController(ctx, log, ENV);
+      await ctrl.listTopics(ctx);
+      const [, params] = serviceStub.getTopics.firstCall.args;
+      expect(params.brandName).to.be.undefined;
+      expect(log.warn.calledWithMatch(/falls back to brand-agnostic counts/)).to.equal(true);
     });
   });
 

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -830,11 +830,11 @@ describe('ElementsController', () => {
       expect(params.enrichUserIntent).to.equal(true);
     });
 
-    it('resolves the brand uuid via resolveBrandUuid before querying', async () => {
+    it('resolves the brand identity via getBrandIdentity before querying', async () => {
       const ctx = fakeContext({ url: promptsUrl() });
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       await ctrl.listPrompts(ctx);
-      expect(resolveBrandUuidStub).to.have.been.calledWith(ORG_ID, BRAND_ID, sinon.match.object);
+      expect(getBrandIdentityStub).to.have.been.calledWith(ORG_ID, BRAND_ID, sinon.match.object);
       expect(resolveBrandWorkspaceStub)
         .to.have.been.calledWith(sinon.match.object, ORG_ID, BRAND_ID);
     });
@@ -874,7 +874,7 @@ describe('ElementsController', () => {
     });
 
     it('404s when the brand does not resolve for the org', async () => {
-      resolveBrandUuidStub.resolves(null);
+      getBrandIdentityStub.resolves(null);
       const ctx = fakeContext({ url: promptsUrl() });
       const ctrl = ElementsController(ctx, fakeLog(), ENV);
       const res = await ctrl.listPrompts(ctx);

--- a/test/support/elements/definitions/topic-prompts.test.js
+++ b/test/support/elements/definitions/topic-prompts.test.js
@@ -78,6 +78,19 @@ describe('topic-prompts definitions', () => {
       expect(findFilterVal(buildTopicPromptsPayload(), 'CBF_brand')).to.be.undefined;
     });
 
+    // `hasText` is `!!str && isString(str)` and does NOT trim, so a whitespace-only name
+    // would pass a hasText guard while matching no brand upstream — silently zeroing the
+    // counts. The builder trims, so it is treated as absent (brand-agnostic) instead.
+    it('treats a whitespace-only brandName as absent (no garbage CBF_brand)', () => {
+      expect(findFilterVal(buildTopicPromptsPayload({ brandName: '   ' }), 'CBF_brand'))
+        .to.be.undefined;
+    });
+
+    it('trims surrounding whitespace off brandName', () => {
+      expect(findFilterVal(buildTopicPromptsPayload({ brandName: '  Lovesac  ' }), 'CBF_brand'))
+        .to.equal('Lovesac');
+    });
+
     it('includes CBF_project (in an or-block) when projectId is provided', () => {
       expect(findFilterVal(buildTopicPromptsPayload({ projectId: 'proj-42' }), 'CBF_project'))
         .to.equal('proj-42');

--- a/test/support/elements/definitions/topic-prompts.test.js
+++ b/test/support/elements/definitions/topic-prompts.test.js
@@ -69,6 +69,15 @@ describe('topic-prompts definitions', () => {
       expect(findFilterVal(buildTopicPromptsPayload(), 'CBF_topic')).to.be.undefined;
     });
 
+    it('scopes to the brand via a CBF_brand or-block when brandName is provided', () => {
+      expect(findFilterVal(buildTopicPromptsPayload({ brandName: 'Lovesac' }), 'CBF_brand'))
+        .to.equal('Lovesac');
+    });
+
+    it('omits CBF_brand when brandName is not provided (brand-agnostic, unchanged)', () => {
+      expect(findFilterVal(buildTopicPromptsPayload(), 'CBF_brand')).to.be.undefined;
+    });
+
     it('includes CBF_project (in an or-block) when projectId is provided', () => {
       expect(findFilterVal(buildTopicPromptsPayload({ projectId: 'proj-42' }), 'CBF_project'))
         .to.equal('proj-42');


### PR DESCRIPTION
## Problem

The Semrush `PROMPTS_BY_TOPIC` element (`78864493`) is **not** brand-scoped by the brand's sub-workspace, contrary to what its module header asserted. Without a `CBF_brand` filter it counts **any** tracked brand appearing in a topic's responses, so a competitor mentioned in an answer where the brand is absent corrupts the brand's `mentions` / `visibility` / `citations`.

The premise was never verified end-to-end — the commit that introduced it (`720e9f0604`, LLMO-6418) left "End-to-end verification against a properly-provisioned Semrush brand" as an explicitly unchecked box.

**Live disproof** (Lovesac sub-workspace, `chatgpt`, 2026-08-17..2026-08-23), topic "3 ft Bean Bag":

| | mentions | citations | visibility | executions |
|---|---|---|---|---|
| without `CBF_brand` (today) | 1 | 5 | 14.29 | 7 |
| with `CBF_brand=Lovesac` | 0 | 0 | 0 | 7 |

That prompt's ChatGPT answer named **Pottery Barn** and never mentioned Lovesac. The Brand Presence MFE — which does send `CBF_brand` — correctly shows 0.

## What changed

- **`topic-prompts.js`** — `buildTopicPromptsPayload` takes an optional `brandName` and emits a `CBF_brand` or-block, matching the file's existing `CBF_model`/`CBF_topic`/`CBF_project` shape. The module header has been rewritten; it previously stated the opposite.
- **`elements.js`** — `authorizeBrandSubWorkspace` resolves the brand via `getBrandIdentity` instead of `resolveBrandUuid` and returns `{ workspaceId, brandUuid, brand }`, so one lookup serves both the auth guard and the `CBF_brand` value. `listTopicPrompts` and `listTopics` both pass `brandName`.
- **`getTopics` is fixed too**, deliberately: it shares the same builder, so fixing only the drill-down would have left the topic **table** reporting 14.29% while its own drill-down reported 0.
- Sibling definitions that still assert the disproven premise are **annotated as unverified**, not changed.

## Reviewer notes

- **Blast radius:** every consumer of `listTopicPrompts` / `listTopics` (opportunity workspace, SR prompt recommendations, competitor research) now gets brand-scoped numbers. Correct, but a visible metric change.
- **Movement goes both ways.** In an all-topics probe, 782 of 1520 rows changed and some went **up** — e.g. "Which ottomans fit well with my Lovesac Sactionals…" moved 21.8 → 100 visibility. Unfiltered, the element returns a blended cross-brand aggregate, not merely an inflated one.
- **`CBF_brand` filters mention attribution, not row membership** — verified: `executions` stayed at 7, and all 1520 rows survived the filter. `totalCount` and pagination are unaffected.
- **Error-semantics delta:** `resolveBrandUuid` returned `null` on a PostgREST *error* (→ 404); `getBrandIdentity` throws (→ 5xx via `mapError`). The documented contracts hold — non-UUID → 400, brand-not-in-org → 404 — since a missing brand still yields `null`. Only a genuine DB failure changed, from a misleading 404 to a correct 5xx. This sits in the shared `authorizeBrandSubWorkspace`, so it applies to **all four** of its callers — `listPrompts`, `listUrlPrompts`, `listTopics` and `listTopicPrompts` — not just the two endpoints this PR fixes.
- **`CBF_brand` matching is exact and case-sensitive, and aliases are not resolved** (verified live 2026-09-08): `Lovesac` → 315 mentions, `lovesac` → 0, registered alias `PillowSac` → 0, over an identical 45-row set. The value sent must be the brand's exact Semrush-tracked name; a rename/casing/alias divergence from `brands.name` would silently zero the aggregates.
- **Follow-up (not fixed here):** the same premise is still unverified for `url-prompts`, `sentiment-overview`, `cited-domains`, `reddit-threads`, `subreddits` and `youtube-videos`. Each needs its own MFE reconciliation.

## Testing the PR changes

Verified in this session:

- `npm test` — **18093 passing, 0 failing**, coverage gate clean. Includes two new builder tests (`CBF_brand` present when `brandName` is given; absent when not) and two updated `listPrompts` assertions (`resolveBrandUuid` → `getBrandIdentity`).
- `npm run lint` — clean.
- `npm run type-check` — clean (both `:base` and `:strict`).
- **Live reconciliation against prod Semrush**, driving the patched `buildTopicPromptsPayload` through the repo's real transport on the Lovesac sub-workspace:
  - "3 ft Bean Bag" → `14.29 / 1 / 5` collapses to `0 / 0 / 0`, matching the MFE.
  - Brand-dominant prompts unchanged (e.g. "What Lovesac ottoman fits well in a narrow entryway…" stays visibility 100, mentions 7).
  - The `or`-block wrapper reconciled, so no fallback to the MFE's bare `eq` was needed.

Not verified: whether Semrush resolves brand **aliases** for `CBF_brand` (probes covered exact display-name matching only — noted `[unverified]` in the JSDoc). No integration test was added; both controller handlers sit inside pre-existing `/* c8 ignore -- LLMO-6418 POC endpoint; unit tests intentionally deferred */` blocks.

## Screenshots/Videos

_(n/a — backend only)_

## Related Issues

https://jira.corp.adobe.com/browse/LLMO-7443

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Josep López", "Dominique Jäggi"]
rationale: "Corrects a metric-attribution bug reaching multiple downstream consumers; response contract unchanged, reversible by redeploy despite wide blast radius."
```