### PR TITLE
fix(security): harden merged SEC-5 async-job access primitive (#3222)

### DIFF
--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -352,13 +352,16 @@ function PreflightController(ctx, log, env) {
       // Emit the terminal-state observability log (shared with the Mystique path).
       logPreflightOutcome(log, PREFLIGHT_PROCESS_AUDW, job);
 
-      // Preflight-shaped metadata allowlist. Retains `metadata.payload` (a superset
-      // of what the ASO preflight MFE reads: payload.{step,reason,errorCode,...}),
-      // plus jobType/tags, but never any top-level token field (e.g. promiseToken).
-      // Preflight jobs carry no token — it travels on the SQS message, not the
-      // record — so returning the payload leaks nothing. Metadata is guaranteed
-      // present: loadJobScopedToCaller admitted this job by its metadata.jobType.
+      // Preflight-shaped metadata allowlist. Projects an explicit field allowlist —
+      // jobType/tags plus payload.{step,reason,errorCode,siteId,urls} — rather than
+      // returning the verbatim `metadata.payload`. Returning the whole payload would
+      // reintroduce the SEC-5 leak one level deeper if payload ever grew a sensitive
+      // field. The allowlisted payload fields are exactly what the ASO preflight MFE
+      // reads (payload.{step,reason,errorCode}); step/reason/errorCode must survive.
+      // Metadata is guaranteed present: loadJobScopedToCaller admitted this job by its
+      // metadata.jobType. `payload` may be absent on a malformed record — guard it.
       const metadata = job.getMetadata();
+      const payload = metadata.payload ?? {};
 
       return ok({
         jobId: job.getId(),
@@ -375,7 +378,13 @@ function PreflightController(ctx, log, env) {
         metadata: {
           jobType: metadata.jobType,
           tags: metadata.tags,
-          payload: metadata.payload,
+          payload: {
+            step: payload.step,
+            reason: payload.reason,
+            errorCode: payload.errorCode,
+            siteId: payload.siteId,
+            urls: payload.urls,
+          },
         },
       });
     } catch (error) {

--- a/src/controllers/preflight.js
+++ b/src/controllers/preflight.js
@@ -30,6 +30,18 @@ import {
 export const AUDIT_STEP_IDENTIFY = 'identify';
 export const AUDIT_STEP_SUGGEST = 'suggest';
 
+/**
+ * The ONLY `metadata.payload` fields the preflight job-status DTO exposes — exactly
+ * what the ASO preflight MFE reads. The reader projects these explicitly rather than
+ * returning the verbatim `metadata.payload`, so a future/sensitive field on `payload`
+ * can never leak (the SEC-5 defence one level deeper). Adding a field the MFE needs is
+ * a one-line change here, and the unit test imports this same constant so its
+ * allowlist assertion can never drift from the projection.
+ */
+export const PREFLIGHT_PAYLOAD_ALLOWLIST = Object.freeze([
+  'step', 'reason', 'errorCode', 'siteId', 'urls',
+]);
+
 const ACCESSIBILITY_AUDIT_NAME = 'accessibility';
 
 /**
@@ -352,16 +364,19 @@ function PreflightController(ctx, log, env) {
       // Emit the terminal-state observability log (shared with the Mystique path).
       logPreflightOutcome(log, PREFLIGHT_PROCESS_AUDW, job);
 
-      // Preflight-shaped metadata allowlist. Projects an explicit field allowlist —
-      // jobType/tags plus payload.{step,reason,errorCode,siteId,urls} — rather than
-      // returning the verbatim `metadata.payload`. Returning the whole payload would
-      // reintroduce the SEC-5 leak one level deeper if payload ever grew a sensitive
-      // field. The allowlisted payload fields are exactly what the ASO preflight MFE
-      // reads (payload.{step,reason,errorCode}); step/reason/errorCode must survive.
-      // Metadata is guaranteed present: loadJobScopedToCaller admitted this job by its
-      // metadata.jobType. `payload` may be absent on a malformed record — guard it.
+      // Preflight-shaped metadata allowlist. Projects an explicit field allowlist
+      // ({@link PREFLIGHT_PAYLOAD_ALLOWLIST}: jobType/tags plus the allowlisted
+      // payload fields) rather than returning the verbatim `metadata.payload` —
+      // returning the whole payload would reintroduce the SEC-5 leak one level
+      // deeper if payload ever grew a sensitive field. Metadata is guaranteed
+      // present: loadJobScopedToCaller admitted this job by its metadata.jobType.
+      // `payload` may be absent on a malformed record — guard it.
       const metadata = job.getMetadata();
       const payload = metadata.payload ?? {};
+      const projectedPayload = PREFLIGHT_PAYLOAD_ALLOWLIST.reduce((acc, key) => {
+        acc[key] = payload[key];
+        return acc;
+      }, {});
 
       return ok({
         jobId: job.getId(),
@@ -378,13 +393,7 @@ function PreflightController(ctx, log, env) {
         metadata: {
           jobType: metadata.jobType,
           tags: metadata.tags,
-          payload: {
-            step: payload.step,
-            reason: payload.reason,
-            errorCode: payload.errorCode,
-            siteId: payload.siteId,
-            urls: payload.urls,
-          },
+          payload: projectedPayload,
         },
       });
     } catch (error) {

--- a/src/support/async-job-access.js
+++ b/src/support/async-job-access.js
@@ -28,12 +28,17 @@ import AccessControlUtil from './access-control-util.js';
  *     `allowedJobTypes` is reported as *not found* (404), never revealing that a job
  *     of a different type exists. An endpoint scoped to `['preflight']` therefore can
  *     never be used to read a `serenity-classify-prompts` (token-bearing) job.
- *  2. **owner scoping** — when `resolveOwnerSiteId` yields a siteId, the caller must
- *     hold access to that site (the same org-membership check `site:read` routes
- *     already enforce via {@link AccessControlUtil#hasAccess}). A caller without
- *     access gets 404 (again, no existence disclosure). Job types with no owning
- *     site (e.g. `site-detection`, whose metadata carries `{ domain, hlxVersion }`
- *     and no siteId) omit the resolver and are scoped by jobType only.
+ *  2. **owner scoping** — when a `resolveOwnerSiteId` resolver is supplied, the caller
+ *     must hold access to the site it yields (the same org-membership check `site:read`
+ *     routes already enforce via {@link AccessControlUtil#hasAccess}). A caller without
+ *     access gets 404 (again, no existence disclosure). This scoping is **fail-closed**:
+ *     if a resolver is supplied but yields no siteId (a job that should be owned but
+ *     carries no owner — a malformed or partially-written record), the job is denied
+ *     (404) rather than returned. Only job types with no owning site at all
+ *     (e.g. `site-detection`, whose metadata carries `{ domain, hlxVersion }` and no
+ *     siteId) omit the resolver entirely; those are intentionally scoped by jobType
+ *     only. "No resolver supplied" (ownerless, allowed) is thus distinct from "resolver
+ *     supplied but empty" (owned-but-unresolvable, denied).
  *
  * The caller projects a response DTO from the returned job — this primitive never
  * returns raw metadata to the client.
@@ -63,8 +68,16 @@ export async function loadJobScopedToCaller(context, {
     return { error: notFound(`Job with ID ${jobId} not found`) };
   }
 
-  const siteId = resolveOwnerSiteId ? resolveOwnerSiteId(job) : undefined;
-  if (hasText(siteId)) {
+  // Distinguish "no resolver supplied" (ownerless job type — jobType-only scope,
+  // allowed) from "resolver supplied but empty" (a job that should be owned but
+  // resolves to no siteId — fail closed, deny). Returning the job in the latter case
+  // would be a fail-open default in a security primitive.
+  if (resolveOwnerSiteId) {
+    const siteId = resolveOwnerSiteId(job);
+    if (!hasText(siteId)) {
+      log?.warn?.(`[async-job-access] job ${jobId} has an owner resolver but no resolvable siteId; denying`);
+      return { error: notFound(`Job with ID ${jobId} not found`) };
+    }
     const site = await dataAccess.Site.findById(siteId);
     if (!site) {
       log?.warn?.(`[async-job-access] job ${jobId} references missing site ${siteId}; denying`);

--- a/src/support/async-job-access.js
+++ b/src/support/async-job-access.js
@@ -49,7 +49,10 @@ import AccessControlUtil from './access-control-util.js';
  * @param {string} params.jobId - The AsyncJob UUID (already format-validated by the caller).
  * @param {string[]} params.allowedJobTypes - Job types this endpoint may return.
  * @param {(job: object) => (string|undefined)} [params.resolveOwnerSiteId] - Resolves the
- *   owning siteId from the job; omit for ownerless job types.
+ *   owning siteId from the job. When SUPPLIED, it is authoritative and fail-closed:
+ *   a resolver that returns `undefined`/empty denies the job (404) rather than
+ *   skipping the ownership check. Omit it ONLY for job types that have no owning
+ *   site at all (scoped by jobType alone).
  * @returns {Promise<{ job?: object, error?: object }>} Exactly one of `job`
  *   (authorized) or `error` (an HTTP response to return as-is).
  */
@@ -75,17 +78,20 @@ export async function loadJobScopedToCaller(context, {
   if (resolveOwnerSiteId) {
     const siteId = resolveOwnerSiteId(job);
     if (!hasText(siteId)) {
-      log?.warn?.(`[async-job-access] job ${jobId} has an owner resolver but no resolvable siteId; denying`);
+      // The jobType is logged so a misconfigured resolver (wrong field path for
+      // this job type) is distinguishable from a data-quality issue (a legitimate
+      // record written without its owner siteId).
+      log?.warn?.(`[async-job-access] job ${jobId} (jobType=${jobType}) has an owner resolver but no resolvable siteId; denying`);
       return { error: notFound(`Job with ID ${jobId} not found`) };
     }
     const site = await dataAccess.Site.findById(siteId);
     if (!site) {
-      log?.warn?.(`[async-job-access] job ${jobId} references missing site ${siteId}; denying`);
+      log?.warn?.(`[async-job-access] job ${jobId} (jobType=${jobType}) references missing site ${siteId}; denying`);
       return { error: notFound(`Job with ID ${jobId} not found`) };
     }
     const accessControlUtil = AccessControlUtil.fromContext(context);
     if (!await accessControlUtil.hasAccess(site)) {
-      log?.warn?.(`[async-job-access] caller lacks access to site ${siteId} owning job ${jobId}; denying`);
+      log?.warn?.(`[async-job-access] caller lacks access to site ${siteId} owning job ${jobId} (jobType=${jobType}); denying`);
       return { error: notFound(`Job with ID ${jobId} not found`) };
     }
   }

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -1536,6 +1536,117 @@ describe('Preflight Controller', () => {
       expect(body.metadata.promiseToken).to.be.undefined;
       expect(JSON.stringify(body)).to.not.include('should-never-be-returned');
     });
+
+    it('projects a payload field allowlist — keeps MFE fields, drops an injected extra', async () => {
+      // The DTO must project payload.{step,reason,errorCode,siteId,urls} explicitly,
+      // not the verbatim payload. A future/rogue field on payload (here `secret`)
+      // must not survive; the MFE-read fields must.
+      const jobWithExtraPayloadField = {
+        ...mockJob,
+        getMetadata: () => ({
+          jobType: 'preflight',
+          tags: ['preflight'],
+          payload: {
+            siteId: 'test-site-123',
+            urls: ['https://main--example-site.aem.page/test.html'],
+            step: 'suggest',
+            reason: 'user cancelled',
+            errorCode: 'CANCELLED',
+            secret: 'SECRET-PAYLOAD-do-not-leak',
+          },
+        }),
+      };
+      mockDataAccess.AsyncJob.findById = sandbox.stub().resolves(jobWithExtraPayloadField);
+      mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const body = await response.json();
+      // Allowlisted fields are present.
+      expect(body.metadata.payload.step).to.equal('suggest');
+      expect(body.metadata.payload.reason).to.equal('user cancelled');
+      expect(body.metadata.payload.errorCode).to.equal('CANCELLED');
+      expect(body.metadata.payload.siteId).to.equal('test-site-123');
+      expect(body.metadata.payload.urls).to.deep.equal(['https://main--example-site.aem.page/test.html']);
+      // Exactly the allowlist — nothing else.
+      expect(Object.keys(body.metadata.payload).sort())
+        .to.deep.equal(['errorCode', 'reason', 'siteId', 'step', 'urls']);
+      // The injected extra field is dropped, from body and any log line.
+      expect(body.metadata.payload.secret).to.be.undefined;
+      expect(JSON.stringify(body)).to.not.include('SECRET-PAYLOAD-do-not-leak');
+      const allLogArgs = [
+        ...loggerStub.debug.getCalls(),
+        ...loggerStub.info.getCalls(),
+        ...loggerStub.warn.getCalls(),
+        ...loggerStub.error.getCalls(),
+      ].map((c) => JSON.stringify(c.args)).join(' ');
+      expect(allLogArgs).to.not.include('SECRET-PAYLOAD-do-not-leak');
+    });
+
+    it('returns 200 for a legitimately-owned job and never logs a token on the success path', async () => {
+      // The token-absence regression was originally asserted only on the gate-rejected
+      // (404) path, yet the `JSON.stringify(job)` logging risk lived on the return
+      // path. Assert the success (200) path too: an owned preflight job that happens to
+      // carry a top-level token is returned, and no token appears in any log line.
+      const TOKEN = 'SECRET-PROMISE-TOKEN-success-path';
+      const ownedJobWithToken = {
+        ...mockJob,
+        getMetadata: () => ({
+          jobType: 'preflight',
+          tags: ['preflight'],
+          promiseToken: TOKEN,
+          payload: {
+            siteId: 'test-site-123',
+            urls: ['https://main--example-site.aem.page/test.html'],
+            step: 'identify',
+          },
+        }),
+      };
+      mockDataAccess.AsyncJob.findById = sandbox.stub().resolves(ownedJobWithToken);
+      mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
+      loggerStub.debug.resetHistory();
+      loggerStub.info.resetHistory();
+      loggerStub.warn.resetHistory();
+      loggerStub.error.resetHistory();
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      expect(response.status).to.equal(200);
+
+      const body = await response.json();
+      // The token is neither echoed in the DTO nor written to any log line.
+      expect(body.metadata.promiseToken).to.be.undefined;
+      expect(JSON.stringify(body)).to.not.include(TOKEN);
+      const allLogArgs = [
+        ...loggerStub.debug.getCalls(),
+        ...loggerStub.info.getCalls(),
+        ...loggerStub.warn.getCalls(),
+        ...loggerStub.error.getCalls(),
+      ].map((c) => JSON.stringify(c.args)).join(' ');
+      expect(allLogArgs).to.not.include(TOKEN);
+    });
+
+    it('returns 200 with an empty payload allowlist for a job whose metadata has no payload', async () => {
+      // A malformed/partially-written preflight record (metadata present — it passed
+      // the jobType gate — but no payload) must not throw; the DTO returns an
+      // all-undefined payload allowlist.
+      const jobNoPayload = {
+        ...mockJob,
+        getMetadata: () => ({ jobType: 'preflight', tags: ['preflight'] }),
+      };
+      mockDataAccess.AsyncJob.findById = sandbox.stub().resolves(jobNoPayload);
+      mockDataAccess.Site.findById = sandbox.stub().resolves(mockSite);
+
+      const context = { params: { jobId } };
+      const response = await preflightController.getPreflightJobStatusAndResult(context);
+      // Note: with no payload.siteId, ownership cannot be resolved, so the primitive
+      // fails closed (404) rather than returning the job — see async-job-access.
+      expect(response.status).to.equal(404);
+      const body = await response.json();
+      expect(body).to.deep.equal({ message: `Job with ID ${jobId} not found` });
+    });
   });
 });
 

--- a/test/controllers/preflight.test.js
+++ b/test/controllers/preflight.test.js
@@ -24,6 +24,7 @@ import * as utils from '../../src/support/utils.js';
 import PreflightController, {
   countIssuesForAudit,
   PREFLIGHT_PROCESS_AUDW,
+  PREFLIGHT_PAYLOAD_ALLOWLIST,
 } from '../../src/controllers/preflight.js';
 
 // Make fetch available globally
@@ -1570,9 +1571,10 @@ describe('Preflight Controller', () => {
       expect(body.metadata.payload.errorCode).to.equal('CANCELLED');
       expect(body.metadata.payload.siteId).to.equal('test-site-123');
       expect(body.metadata.payload.urls).to.deep.equal(['https://main--example-site.aem.page/test.html']);
-      // Exactly the allowlist — nothing else.
+      // Exactly the allowlist — nothing else. Assert against the shared constant so
+      // this can never drift from the controller's projection.
       expect(Object.keys(body.metadata.payload).sort())
-        .to.deep.equal(['errorCode', 'reason', 'siteId', 'step', 'urls']);
+        .to.deep.equal([...PREFLIGHT_PAYLOAD_ALLOWLIST].sort());
       // The injected extra field is dropped, from body and any log line.
       expect(body.metadata.payload.secret).to.be.undefined;
       expect(JSON.stringify(body)).to.not.include('SECRET-PAYLOAD-do-not-leak');
@@ -1628,10 +1630,11 @@ describe('Preflight Controller', () => {
       expect(allLogArgs).to.not.include(TOKEN);
     });
 
-    it('returns 200 with an empty payload allowlist for a job whose metadata has no payload', async () => {
+    it('returns 404 (fail-closed) for a job whose metadata has no payload — resolver yields no siteId', async () => {
       // A malformed/partially-written preflight record (metadata present — it passed
-      // the jobType gate — but no payload) must not throw; the DTO returns an
-      // all-undefined payload allowlist.
+      // the jobType gate — but no payload) has no resolvable owner siteId, so the
+      // ownership resolver yields undefined and the primitive fails CLOSED (404),
+      // never returning the job. It must not throw.
       const jobNoPayload = {
         ...mockJob,
         getMetadata: () => ({ jobType: 'preflight', tags: ['preflight'] }),

--- a/test/it/postgres/seed-data/async-jobs.js
+++ b/test/it/postgres/seed-data/async-jobs.js
@@ -26,6 +26,11 @@
  */
 export const SERENITY_CLASSIFY_JOB_ID = 'eeee3333-3333-4333-a333-333333333333';
 
+// A COMPLETED preflight job owned by SITE_3 (organization ORG_2 — the "denied" org
+// for the `user` persona). Used to assert that GET /preflight/jobs/{jobId} returns
+// 404 (no existence disclosure) for a caller who does not own the job's site.
+export const SITE_3_PREFLIGHT_JOB_ID = 'eeee4444-4444-4444-b444-444444444444';
+
 export const asyncJobs = [
   {
     id: 'eeee2222-2222-4222-a222-222222222222',
@@ -78,5 +83,25 @@ export const asyncJobs = [
     },
     started_at: '2025-02-01T09:00:00.000Z',
     ended_at: '2025-02-01T09:01:00.000Z',
+  },
+  {
+    id: SITE_3_PREFLIGHT_JOB_ID,
+    status: 'COMPLETED',
+    result_location: 'https://results.example.com/preflight-003',
+    result_type: 'URL',
+    result: { summary: { totalIssues: 0, criticalIssues: 0 } },
+    metadata: {
+      payload: {
+        // SITE_3_ID — ORG_2, denied to the `user` persona. Literal to keep this seed
+        // file free of a cross-import dependency on seed-ids.js.
+        siteId: '55555555-5555-4555-9555-555555555555',
+        urls: ['https://site3-denied.example.com/page1'],
+        step: 'identify',
+      },
+      jobType: 'preflight',
+      tags: ['preflight'],
+    },
+    started_at: '2025-02-02T09:00:00.000Z',
+    ended_at: '2025-02-02T09:05:00.000Z',
   },
 ];

--- a/test/it/shared/tests/preflight.js
+++ b/test/it/shared/tests/preflight.js
@@ -14,7 +14,12 @@ import { expect } from 'chai';
 import {
   ASYNC_JOB_1_ID,
   NON_EXISTENT_JOB_ID,
+  SITE_1_ID,
 } from '../seed-ids.js';
+import {
+  SERENITY_CLASSIFY_JOB_ID,
+  SITE_3_PREFLIGHT_JOB_ID,
+} from '../../postgres/seed-data/async-jobs.js';
 
 /**
  * Shared Preflight endpoint tests.
@@ -126,6 +131,45 @@ export default function preflightTests(getHttpClient, resetData, options = {}) {
           expect(job.endedAt).to.be.a('string');
           expect(job.createdAt).to.be.a('string');
           expect(job.updatedAt).to.be.a('string');
+        });
+
+        // ── SEC-5: cross-tenant credential-exposure (IDOR) scoping ──
+        // The generic AsyncJob table is keyed only by UUID; without scoping any
+        // caller with any job UUID could read any tenant's job (including
+        // token-bearing types). loadJobScopedToCaller enforces jobType + ownership.
+
+        it('owner: returns 200 with the payload field allowlist (MFE contract)', async () => {
+          // SITE_1 belongs to ORG_1, of which the `user` persona is a member.
+          const http = getHttpClient();
+          const res = await http.user.get(`/preflight/jobs/${ASYNC_JOB_1_ID}`);
+          expect(res.status).to.equal(200);
+          expect(res.body.jobId).to.equal(ASYNC_JOB_1_ID);
+          expect(res.body.metadata.jobType).to.equal('preflight');
+          // The DTO projects an explicit payload allowlist. The MFE-read fields survive…
+          expect(res.body.metadata.payload.step).to.equal('identify');
+          expect(res.body.metadata.payload.siteId).to.equal(SITE_1_ID);
+          expect(res.body.metadata.payload.urls).to.be.an('array');
+          // …and no key outside the allowlist is present.
+          expect(Object.keys(res.body.metadata.payload))
+            .to.have.members(['step', 'siteId', 'urls']);
+        });
+
+        it('returns 404 for a preflight job owned by a different tenant (no cross-tenant read)', async () => {
+          // SITE_3 is ORG_2 — denied to the `user` persona. The job exists, but its
+          // existence must not be disclosed to a non-owner.
+          const http = getHttpClient();
+          const res = await http.user.get(`/preflight/jobs/${SITE_3_PREFLIGHT_JOB_ID}`);
+          expect(res.status).to.equal(404);
+        });
+
+        it('returns 404 for a token-bearing non-preflight job and never leaks its token', async () => {
+          // A serenity-classify-prompts job persists a live promise token on metadata.
+          // The preflight endpoint (allowlist ['preflight']) must reject it as 404 and
+          // never surface the token in the response body.
+          const http = getHttpClient();
+          const res = await http.admin.get(`/preflight/jobs/${SERENITY_CLASSIFY_JOB_ID}`);
+          expect(res.status).to.equal(404);
+          expect(JSON.stringify(res.body)).to.not.include('do-not-leak');
         });
       }
     });

--- a/test/support/async-job-access.test.js
+++ b/test/support/async-job-access.test.js
@@ -152,18 +152,23 @@ describe('loadJobScopedToCaller', () => {
     expect(context.dataAccess.Site.findById).to.not.have.been.called;
   });
 
-  it('skips the ownership check when the resolver returns no siteId', async () => {
+  it('denies (404) when a resolver is supplied but yields no siteId (fail closed)', async () => {
+    // A resolver was supplied, so the job is expected to be owned. Resolving to no
+    // siteId (a malformed/partially-written record) must DENY, not fall open and
+    // return the job. This is distinct from the ownerless "no resolver" path below.
     const context = makeContext();
-    const job = makeJob({ jobType: 'site-detection', payload: {} });
+    const job = makeJob({ jobType: 'preflight', payload: {} });
     context.dataAccess.AsyncJob.findById.resolves(job);
 
     const result = await loadJobScopedToCaller(context, {
       jobId,
-      allowedJobTypes: ['site-detection'],
+      allowedJobTypes: ['preflight'],
       resolveOwnerSiteId: (j) => j.getMetadata().payload.siteId, // undefined
     });
 
-    expect(result.job).to.equal(job);
+    expect(result.job).to.be.undefined;
+    expect(result.error.status).to.equal(404);
+    // Denied before any site lookup.
     expect(context.dataAccess.Site.findById).to.not.have.been.called;
   });
 });


### PR DESCRIPTION
## What & why

Defense-in-depth follow-up to the **already-merged SEC-5 fix (#3222)** (the `loadJobScopedToCaller` primitive that closed the cross-tenant `AsyncJob` IDOR / credential-exposure). A 6-reviewer panel flagged two residual gaps in the merged fix; this PR hardens them and adds coverage. It does **not** touch #3222 (merged) — it builds on it.

Design reference: **#3203** (SEC-5 DTO / field-allowlist design). `Introduced by: #3222`.

### 1. Fail-closed ownership default — `src/support/async-job-access.js`
Previously, when a `resolveOwnerSiteId` resolver **was** supplied but returned a falsy/empty siteId, the ownership check was skipped and the job was returned — a **fail-open default in a security primitive**. Now the primitive distinguishes:
- **No resolver supplied** → ownerless job type (e.g. the `sites/detect` reader, whose jobs store `{domain,hlxVersion}` and no siteId): intentionally jobType-only-scoped, **still allowed** (unchanged).
- **Resolver supplied but yields no siteId** → owned-but-unresolvable (malformed/partially-written record): **now denied** with the same `notFound(...)` 404.

JSDoc updated to document the distinction.

### 2. Field-allowlist `metadata.payload` — `src/controllers/preflight.js`
The `getPreflightJobStatusAndResult` DTO returned the **verbatim** `metadata.payload`. It now projects an **explicit field allowlist** — `payload.{step,reason,errorCode,siteId,urls}` — so the payload can never reintroduce the leak one level deeper if it later grows a sensitive field. The ASO preflight MFE contract fields (`payload.{step,reason,errorCode}`) are preserved.

### Tests
- **Unit** (`async-job-access.test.js`): resolver supplied + returns undefined → 404 (not the job). The genuinely-ownerless "no resolver" path still returns the job.
- **Controller** (`preflight.test.js`): payload allowlist keeps the MFE fields and **excludes** an injected `payload.secret`; a **success (200) path** token-absence assertion (no token in any log line for a legitimately-owned job carrying a top-level token); a malformed/missing-`payload` metadata case.
- **Integration** (`test/it/shared/tests/preflight.js` + a SITE_3-owned preflight seed job): owner → 200 with the allowlisted DTO; cross-tenant preflight job → 404; the token-bearing `serenity-classify-prompts` seed job (`promiseToken: 'do-not-leak'`) fetched through `GET /preflight/jobs/:jobId` → 404 with the token absent from the response.

### Known open question (contested finding — deliberately NOT changed here)
One reviewer argued that the bare `hasAccess(site)` check (no `productCode`) ignores **delegated/agency grants** the FACS `can_view` map allows, so a delegated tenant could receive a 404. Two other reviewers held that it matches the dominant read-auth convention in this codebase. This PR **leaves the auth check as-is** and records the disagreement here for a human to adjudicate — no behavior change to the access check.

## Verification
- `npm run lint` — pass (exit 0).
- `npm test` — pass (18108 passing, exit 0).
- MFE-read fields (`payload.step/reason/errorCode`) confirmed to survive the allowlist (unit + integration assertions).

## Related Issues
- Builds on #3222 (merged SEC-5 fix) — `Introduced by: #3222`
- Design: #3203

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "Hardens the merged SEC-5 access primitive (fail-closed ownership deny + preflight payload field-allowlist) plus tests. Access-control change, but fully reversible by redeploying the previous release and recoverable; legitimate preflight jobs always carry payload.siteId so no legitimate lockout; gated by CI/tests/review."
recommendations: "After deploy, watch preflight GET 404 rates to confirm no unexpected owner denials."
backout: "Redeploy the previous release."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
