### PR TITLE
ci: remove redundant Actions runs to cut shared-runner queue time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,16 @@ permissions:
   pull-requests: write
 
 on:
+  # `push:` stays unfiltered (all branches): the `type-check` push-fallback and
+  # `semver-check` deliberately run on non-main branch pushes. The redundant copy
+  # of the reusable CI on a feature-branch push is suppressed at the job level
+  # instead (see the `ci` job's `if:` guard), not by filtering the trigger.
   push:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened, edited]
+    # `edited` removed: a PR title/body edit fired the full reusable CI (~23
+    # billable job-min, ~5 org runner slots) only to re-check the title. Title
+    # re-validation on edit now lives in the lightweight pr-title.yaml workflow.
+    types: [opened, synchronize, ready_for_review, reopened]
   workflow_dispatch:
     inputs:
       environment:
@@ -20,7 +27,25 @@ on:
         default: dev
 
 jobs:
+  # For an open PR, GitHub fires BOTH a `push` (refs/heads/<branch>) and a
+  # `pull_request` (refs/pull/N/merge) event on every commit. The reusable
+  # service-ci workflow's concurrency group keys on `github.ref`, so the two runs
+  # land in different groups and never cancel each other -- `build` + `it-postgres`
+  # (the only two branch-protection-required checks) run in full TWICE per commit,
+  # ~19 billable job-min and ~3 org-shared runner slots wasted each time.
+  #
+  # This guard runs the reusable CI on exactly the events that need it and skips
+  # only the duplicate non-main `push` run:
+  #   - pull_request (non-draft)  -> reports the required `ci / build` + `ci / it-postgres`
+  #   - push to main              -> semantic-release + deploy-stage
+  #   - workflow_dispatch         -> manual dev/stage/prod deploy (deploy-worker needs: [ci])
+  # Draft PRs are skipped too (a draft cannot merge; `ready_for_review` re-triggers
+  # and reports the required checks). The type-check push-fallback and semver-check
+  # are separate jobs/workflows and are unaffected.
   ci:
+    if: >-
+      (github.event_name != 'push' || github.ref == 'refs/heads/main')
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     uses: adobe/mysticat-ci/.github/workflows/service-ci.yaml@v3
     with:
       service-name: api-service

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,25 @@
+name: PR Title
+
+# Re-validates the PR title on `edited` events only. The main CI workflow
+# (ci.yaml) dropped `edited` from its `pull_request` trigger because a title/body
+# edit fired the entire reusable service-ci workflow (~23 billable job-min, ~5
+# org-shared runner slots) just to re-run the title check. This runs only that
+# check -- one sub-minute job, one slot -- so a title fixed via edit (no new
+# commit) is still validated. Title validation on opened/synchronize/reopened/
+# ready_for_review continues to run inside ci.yaml's reusable `validate-pr-title`
+# job; this workflow deliberately covers only the `edited` gap (no overlap).
+on:
+  pull_request:
+    types: [edited]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
CI-only change to spacecat-api-service's GitHub Actions workflows: guards the reusable CI job so it stops running twice per PR commit, drops the `edited` trigger, skips draft PRs, and adds a lightweight title-only check.

## 2. Reasoning
The `adobe` GitHub org shares a hard cap of ~20 concurrent standard GitHub-hosted runners across 1.3k+ repos, so slow or redundant CI queues the whole org behind it. Real run data (2026-09-08) shows a single commit on an open PR firing three workflow runs = ~45 billable job-minutes and ~8-9 org runner slots requested, of which ~19 min is pure duplication: `build` (~10m) and `it-postgres` (~9m) run in full on both the `push` and the `pull_request` event. One main-push run was observed queued ~6h behind the shared cap. For a public repo on standard runners these minutes cost ~$0, so the scarce resource being reclaimed is org-shared concurrency slots, not spend. Prompted by the org CI-usage / shared-runner-queue initiative in the cq-dev channel.

## 3. High-level overview of the changes
- Guard the reusable `ci` job with a job-level `if:` so it runs only where needed and skips the redundant non-main `push` run. Kept: `pull_request` (non-draft) reports the two required checks; `push` to `main` runs semantic-release + deploy-stage; `workflow_dispatch` runs manual deploys (`deploy-worker` needs the `ci` job).
- Drop `edited` from the `pull_request` trigger - a PR title/body edit was firing the entire reusable CI (~23 job-min, ~5 slots) only to re-check the title.
- Skip draft PRs (same `if:`): a draft cannot merge, and `ready_for_review` re-triggers and reports the required checks.
- Add `pr-title.yaml`: a one-job, sub-minute title check on `edited` only, so a title fixed via edit (no new commit) is still validated without running full CI.

The guard is a job-level `if:` rather than an `on: push` branch filter on purpose: the `type-check` push-fallback (PR 3199) and `semver-check` deliberately run on non-main branch pushes, so `push:` must stay unfiltered.

Before: ~45 job-min / ~8-9 slots per PR commit. After: ~23 job-min / ~4-5 slots - roughly half. No required check is weakened.

## 4. Required information
- Other: cq-dev CI-cost / shared-runner-queue thread — https://cq-dev.slack.com/archives/C6HQ71V5X/p1788878244694929

## 6. Affected / used mysticat-workspace projects
- adobe/mysticat-ci — consumed (contract): this workflow calls its reusable `service-ci.yaml@v3`; the guard changes only which events invoke it, not the reusable workflow itself. Companion shared-workflow optimizations (redundant `npm ci` per job, sub-minute gate jobs) are proposed in a separate mysticat-ci issue.

## 7. Additional information outside the code
- Confirmed via `gh api repos/adobe/spacecat-api-service/branches/main/protection` that the required status checks are exactly `ci / build` and `ci / it-postgres`. Both continue to run on every non-draft PR commit under the new guard, so the change does not strand a required check.

## 8. Test plan
(a) Local: both workflow files validated as YAML; the `if:` guard was reasoned against every trigger (feature-branch push, PR synchronize, draft PR, `ready_for_review`, main push, and `workflow_dispatch` for dev/stage/prod) to confirm the required checks and all deploy paths are preserved.
(b) On this PR (it exercises the new triggers on itself): confirm exactly one CI run reports `ci / build` + `ci / it-postgres` with no duplicate push run, and that `semver-check` still comments. On merge to `main`: confirm semantic-release + deploy-stage still fire; via `workflow_dispatch`, confirm manual deploys still run.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "CI-only change: guards the reusable ci job to skip a duplicate feature-branch push run and draft PRs, drops the edited trigger, and adds a sub-minute title-only check. No production/runtime code; required checks (ci / build, ci / it-postgres) and the main-push deploy path are preserved. Fully reversible by revert."
recommendations: "On the first PR commit, verify both required checks still report and only one CI run fires; confirm a main merge still triggers semantic-release + deploy-stage."
backout: "Revert this PR; workflow-only change, prior trigger behaviour returns on the next push/PR event."
```
