### PR TITLE
fix(slack): keep help reply within Slack's 50-block limit

### DIFF
--- a/src/support/slack/commands/help.js
+++ b/src/support/slack/commands/help.js
@@ -27,6 +27,16 @@ Greetings, I am SpaceCat, an emerging Slack bot. Within my limited abilities, I 
 `;
 
 /**
+ * Slack rejects a chat.postMessage whose `blocks` array exceeds 50 entries, or whose section
+ * `text` exceeds 3000 characters, with an `invalid_blocks` API error - so the whole message is
+ * dropped. Emitting one section block per command overflowed the 50-block limit once the command
+ * list grew past ~49, silently breaking the help reply. Packing several commands per section block
+ * keeps the message well within both limits.
+ * @type {number}
+ */
+const SLACK_SECTION_TEXT_LIMIT = 3000;
+
+/**
  * Creates a HelpCommand instance.
  *
  * @param {Object} context - The context object.
@@ -61,15 +71,25 @@ function HelpCommand(context) {
       },
     }];
 
+    // Pack command descriptions into as few section blocks as possible, keeping each section's
+    // text under Slack's 3000-char limit, so the message stays within the 50-block cap regardless
+    // of how many commands are registered (see SLACK_SECTION_TEXT_LIMIT).
+    let section = '';
+    const flushSection = () => {
+      if (section.length > 0) {
+        blocks.push({ type: 'section', text: { type: 'mrkdwn', text: section } });
+        section = '';
+      }
+    };
+
     for (const command of commands) {
-      blocks.push({
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `*${command.name}*\n${command.usage()}\n${command.description}\n\n`,
-        },
-      });
+      const entry = `*${command.name}*\n${command.usage()}\n${command.description}\n\n`;
+      if (section.length > 0 && section.length + entry.length > SLACK_SECTION_TEXT_LIMIT) {
+        flushSection();
+      }
+      section += entry;
     }
+    flushSection();
 
     await say({ blocks });
   };

--- a/test/support/slack/commands/help.test.js
+++ b/test/support/slack/commands/help.test.js
@@ -48,11 +48,56 @@ describe('HelpCommand', () => {
       expect(slackContext.say.called).to.be.true;
       const { blocks } = slackContext.say.firstCall.args[0];
       expect(blocks[0].text.text).to.include('Greetings, I am SpaceCat');
-      for (let i = 0; i < mockCommands.length; i += 1) {
-        expect(blocks[i + 1].text.text).to.include(mockCommands[i].name);
-        expect(blocks[i + 1].text.text).to.include(mockCommands[i].usage());
-        expect(blocks[i + 1].text.text).to.include(mockCommands[i].description);
+      // Command entries are packed across one or more section blocks after the intro; assert
+      // every command's name, usage and description appears somewhere in the rendered help.
+      const renderedCommands = blocks.slice(1).map((block) => block.text.text).join('\n');
+      for (const mockCommand of mockCommands) {
+        expect(renderedCommands).to.include(mockCommand.name);
+        expect(renderedCommands).to.include(mockCommand.usage());
+        expect(renderedCommands).to.include(mockCommand.description);
       }
+    });
+
+    it('keeps the help message within Slack\'s 50-block limit for large command sets', async () => {
+      const mockCommands = Array.from({ length: 60 }, (_, i) => ({
+        name: `Command${i}`,
+        usage: () => `Usage${i}`,
+        description: `Description${i}`,
+      }));
+      const command = HelpCommand(context);
+
+      await command.handleExecution([], slackContext, mockCommands);
+
+      const { blocks } = slackContext.say.firstCall.args[0];
+      expect(blocks.length).to.be.at.most(50);
+    });
+
+    it('splits commands across section blocks without exceeding the 3000-char limit or dropping any', async () => {
+      // Long descriptions force the packer to split the command list across several section blocks.
+      const mockCommands = Array.from({ length: 60 }, (_, i) => ({
+        name: `Command${i}`,
+        usage: () => `Usage${i}`,
+        description: `Description${i} `.repeat(20).trim(),
+      }));
+      const command = HelpCommand(context);
+
+      await command.handleExecution([], slackContext, mockCommands);
+
+      const { blocks } = slackContext.say.firstCall.args[0];
+      expect(blocks.length).to.be.greaterThan(2); // intro + at least two packed blocks
+      blocks.forEach((block) => expect(block.text.text.length).to.be.at.most(3000));
+      const renderedCommands = blocks.slice(1).map((block) => block.text.text).join('\n');
+      mockCommands.forEach((mockCommand) => expect(renderedCommands).to.include(mockCommand.name));
+    });
+
+    it('renders only the intro block when there are no commands', async () => {
+      const command = HelpCommand(context);
+
+      await command.handleExecution([], slackContext, []);
+
+      const { blocks } = slackContext.say.firstCall.args[0];
+      expect(blocks).to.have.length(1);
+      expect(blocks[0].text.text).to.include('Greetings, I am SpaceCat');
     });
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Fixes the SpaceCat Slack bot's `help` reply, which Slack was rejecting outright so no help text appeared when a user mentioned `@spacecat` / `@spacecat-dev`.

## 2. Reasoning
The help reply — also the fallback for any `app_mention` that doesn't match a known command — stopped posting. Root cause found this session: `help.js` builds one Block Kit section per registered command plus an intro block. With 59 commands registered the message is 60 blocks, over Slack's hard limit of 50 blocks per `chat.postMessage`, so Slack rejects the entire message with an `invalid_blocks` API error and nothing is posted. A signed synthetic `app_mention` sent to the live dev endpoint reproduced it exactly (`HTTP 500 — invalid_blocks`) and, because Slack returns `invalid_blocks` only after authenticating the call, simultaneously proved the bot token, signing secret, and event delivery are all healthy. The recent Slack token revocation/reinstall was a red herring — the block count crossing 50 as commands were added over time is the real, delivery- and token-independent cause.

## 3. High-level overview of the changes
- Before: `help.js` pushed one section block per command (`1 + N` blocks). Once `N` reached ~49 the reply exceeded Slack's 50-block ceiling and every help / unknown-command mention silently produced no reply.
- After: command entries are packed into as few section blocks as possible, each kept under Slack's 3000-character section-text limit. With today's 59 commands the reply is a handful of blocks, far under the cap, and it stays valid no matter how many commands are added later.
- No change to which commands are listed or to their name / usage / description text — only how they are grouped into blocks. An empty command list renders just the intro block.
- User-visible effect: `@spacecat help` (and any unrecognized mention) posts the help message again.

## 4. Required information
- None (standalone bug fix found via live debugging; no tracking issue filed yet).

## 7. Additional information outside the code
Verification performed this session against the live dev / prod stack (no secrets reproduced here):
- Both Vault `SLACK_BOT_TOKEN`s validated via Slack `auth.test` → valid; bots `spacecat` / `spacecatdev` in the AEM Engineering workspace, and both are members of the test channel.
- Signed `url_verification` POSTs to prod `…/api/v1/slack/events` and dev `…/api/ci/slack/events` → HTTP 200 with the challenge echoed, confirming the endpoints are live and the signing secret matches the running Lambda.
- Signed synthetic `app_mention` to the dev endpoint → `HTTP 500 {"message":"An API error occurred: invalid_blocks"}`, reproducing the failure on demand and localizing it to the help message's block count (token and event delivery healthy).

## 8. Test plan
- (a) Local: added unit coverage asserting the rendered help stays within Slack's 50-block and 3000-char-per-section limits for large command sets, that no command is dropped when packed across blocks, and that an empty command list renders only the intro. Ran the repo unit suite locally.
- (b) After deploy:
  - dev: mention `@spacecat-dev` in a channel it belongs to and confirm the help text posts; optionally re-send a signed `app_mention` to `…/api/ci/slack/events` and expect HTTP 200 (no longer `invalid_blocks`).
  - prod: mention `@spacecat` and confirm the help reply posts.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "Fixes the internal Slack ops bot's help reply exceeding Slack's 50-block message limit (invalid_blocks) by packing commands into fewer section blocks. Internal-only, no data or customer-facing surface, reversible by redeploy."
recommendations: "The added unit test guards the 50-block / 3000-char invariant so future command additions cannot silently reintroduce the failure."
backout: "Redeploy the previous release."
```
