### PR TITLE
ci: restore feature-branch auto-deploy disabled by the push-skip guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,10 @@ permissions:
   pull-requests: write
 
 on:
-  # `push:` stays unfiltered (all branches): the `type-check` push-fallback and
-  # `semver-check` deliberately run on non-main branch pushes. The redundant copy
-  # of the reusable CI on a feature-branch push is suppressed at the job level
-  # instead (see the `ci` job's `if:` guard), not by filtering the trigger.
+  # `push:` stays unfiltered (all branches): the `type-check` push-fallback,
+  # `semver-check`, and the reusable workflow's `branch-deploy` job (auto-deploy of
+  # feature branches to the `dev-branches` env, which fires on push only) all run
+  # on non-main branch pushes.
   push:
   pull_request:
     # `edited` removed: a PR title/body edit fired the full reusable CI (~23
@@ -27,25 +27,22 @@ on:
         default: dev
 
 jobs:
-  # For an open PR, GitHub fires BOTH a `push` (refs/heads/<branch>) and a
-  # `pull_request` (refs/pull/N/merge) event on every commit. The reusable
-  # service-ci workflow's concurrency group keys on `github.ref`, so the two runs
-  # land in different groups and never cancel each other -- `build` + `it-postgres`
-  # (the only two branch-protection-required checks) run in full TWICE per commit,
-  # ~19 billable job-min and ~3 org-shared runner slots wasted each time.
+  # The reusable CI runs on both `push` and `pull_request`, so for an open PR its
+  # `build` + `it-postgres` run twice per commit (the concurrency group keys on
+  # `github.ref`, which differs between the two events, so they don't cancel each
+  # other). That duplication is deliberate here: the `push` run uniquely carries
+  # the reusable `branch-deploy` job, which auto-deploys feature branches to the
+  # `dev-branches` env and fires on push only. A previous attempt to skip the
+  # non-main `push` run to dedup (this repo's #3235) silently disabled that. A real
+  # dedup that keeps branch-deploy needs a change in the shared service-ci workflow
+  # (tracked in the mysticat-ci CI-queue issue), not a caller-side push skip.
   #
-  # This guard runs the reusable CI on exactly the events that need it and skips
-  # only the duplicate non-main `push` run:
-  #   - pull_request (non-draft)  -> reports the required `ci / build` + `ci / it-postgres`
-  #   - push to main              -> semantic-release + deploy-stage
-  #   - workflow_dispatch         -> manual dev/stage/prod deploy (deploy-worker needs: [ci])
-  # Draft PRs are skipped too (a draft cannot merge; `ready_for_review` re-triggers
-  # and reports the required checks). The type-check push-fallback and semver-check
-  # are separate jobs/workflows and are unaffected.
+  # The one caller-side saving kept: skip the `pull_request` copy on DRAFT PRs. A
+  # draft can't merge, the `push` run still runs branch-deploy and reports the
+  # required `ci / build` + `ci / it-postgres` on the same commit, and
+  # `ready_for_review` re-triggers the full `pull_request` run.
   ci:
-    if: >-
-      (github.event_name != 'push' || github.ref == 'refs/heads/main')
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: adobe/mysticat-ci/.github/workflows/service-ci.yaml@v3
     with:
       service-name: api-service


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Partial revert of the earlier CI change (spacecat-api-service PR 3235) to restore feature-branch auto-deploy. Keeps that change's draft-PR skip and its `edited`-trigger removal / `pr-title.yaml`.

## 2. Reasoning
PR 3235 guarded the reusable `ci` job to skip on non-main `push`, to remove the duplicate `build`+`it-postgres` that run on both the `push` and `pull_request` events. But the `push` run is not pure duplication: it uniquely carries the reusable `branch-deploy` job, which auto-deploys feature branches to the `dev-branches` environment and fires on **push only**. Skipping the push run silently disabled that. It was actively used - the deployments API showed multiple developers getting `dev-branches` deploys on feature pushes daily, right up to the merge. That behaviour change was not intended or flagged, so this restores it.

## 3. High-level overview of the changes
- Change the `ci` job guard from "skip the non-main push run (and draft PRs)" to simply "skip the `pull_request` copy on draft PRs". The reusable CI runs on `push` again, so `branch-deploy` fires on feature pushes as before.
- Consequence: the `push`/`pull_request` duplication of `build`+`it-postgres` returns for non-draft PRs. That is the accepted cost of keeping both branch-deploy (push) and PR-reported required checks (pull_request) with the current monolithic reusable workflow. Deduping without losing branch-deploy is a shared-workflow change, tracked in the mysticat-ci issue linked below.
- Kept from PR 3235 (both unaffected by branch-deploy): `edited` removed from the `pull_request` trigger, and the lightweight `pr-title.yaml`.
- Draft PRs still skip the `pull_request` copy; the `push` run still reports the required `ci / build` + `ci / it-postgres` on the same commit and runs branch-deploy, and `ready_for_review` re-triggers the full `pull_request` run.

## 4. Required information
- Other: shared-workflow dedup tracking issue — https://github.com/adobe/mysticat-ci/issues/25
- Other: cq-dev CI-cost / shared-runner-queue thread — https://cq-dev.slack.com/archives/C6HQ71V5X/p1788878244694929

## 6. Affected / used mysticat-workspace projects
- adobe/mysticat-ci — consumed (contract): this workflow calls its reusable `service-ci.yaml@v3`. The proper push/PR dedup that keeps `branch-deploy` is deferred to that repo (issue 25); this PR only restores the caller to a branch-deploy-safe trigger set.

## 7. Additional information outside the code
- Confirmed `branch-deploy` was active on api-service before PR 3235: `gh api repos/adobe/spacecat-api-service/deployments?environment=dev-branches` showed 12 `dev-branches` deployments by 8 distinct developers on the PR 3235 merge day alone, on feature branches. `branch-deploy` fires on `push` only, so PR 3235's push-skip guard disabled it.

## 8. Test plan
(a) Local: `ci.yaml` validated as YAML; the guard was reasoned against every trigger (feature-branch push, PR synchronize, draft PR, `ready_for_review`, main push, `workflow_dispatch`) to confirm branch-deploy runs on feature pushes and the required checks still report.
(b) On this PR / after merge: on a green feature-branch push, confirm `ci / branch-deploy` runs and a new `dev-branches` deployment is created (the behaviour PR 3235 removed). On a draft PR, confirm the `pull_request` `ci` copy is skipped while the `push` run still reports `ci / build` + `ci / it-postgres`. On merge to `main`, confirm semantic-release + deploy-stage still fire.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "CI-only change restoring prior behaviour: the reusable ci job runs on push again so branch-deploy (feature-branch auto-deploy to dev-branches, push-only), disabled by PR 3235, works again. Only the draft-PR skip of the pull_request copy is kept. No production/runtime code; required checks continue to report. Fully reversible by revert."
recommendations: "After merge, verify branch-deploy runs on the next green feature push (a dev-branches deployment appears). Proper push/PR dedup that keeps branch-deploy is tracked in adobe/mysticat-ci issue 25."
backout: "Revert this PR; workflow-only change, trigger behaviour returns on the next push/PR event."
```
