### PR TITLE
fix(audit-policy): dedup exclusion globs against RPC-normalized values | SITES-51200

### DIFF
--- a/src/controllers/audit-policy.js
+++ b/src/controllers/audit-policy.js
@@ -236,15 +236,45 @@ export default function AuditPolicyController() {
     return [v, decoded].some((s) => s.includes('../') || s.includes('..\\'));
   }
 
+  // Mirrors the write-time glob-rewrite CASE in wrpc_upsert_audit_policy
+  // (SITES-49858, mysticat-data-service db/migrations/20260814154830_audit_policy_
+  // exclusion_glob_rewrite.sql:102-119) so the controller's own dedup compares
+  // against the same representation the RPC will persist. Defense-in-depth only
+  // (SITES-51200 item 2) — the RPC's own post-rewrite dedup (SITES-51200 item 1)
+  // remains the canonical guarantee against a stored duplicate.
+  function normalizeExclusionGlob(baseURL, value) {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    if (value === '' || value.startsWith('http://') || value.startsWith('https://') || value.startsWith('*')) {
+      return value;
+    }
+    const root = baseURL.replace(/\/+$/, '');
+    return value.startsWith('/') ? `${root}${value}` : `${root}/${value}`;
+  }
+
   // add = set-union (preserves existing order, appends new values in call order);
   // remove = set-difference. Both are no-ops for elements already in the target state,
   // which is what makes retrying this operation safe (§3.2 of the design doc).
-  function computeNewArray(currentArray, values, mode) {
+  // `normalize` mirrors the RPC's own write-time rewrite (see normalizeExclusionGlob)
+  // so membership/no-op checks compare against the value the RPC will actually
+  // persist rather than the raw caller input (SITES-51200 item 2, defense in depth).
+  // Identity for manualUrls, which the RPC never rewrites.
+  function computeNewArray(currentArray, values, mode, normalize) {
     if (mode === 'add') {
-      return [...new Set([...currentArray, ...values])];
+      const seen = new Set();
+      const result = [];
+      [...currentArray, ...values].forEach((v) => {
+        const key = normalize(v);
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push(v);
+        }
+      });
+      return result;
     }
-    const removeSet = new Set(values);
-    return currentArray.filter((v) => !removeSet.has(v));
+    const removeSet = new Set(values.map(normalize));
+    return currentArray.filter((v) => !removeSet.has(normalize(v)));
   }
 
   async function mutateArray(context, resourceKey, mode) {
@@ -284,7 +314,10 @@ export default function AuditPolicyController() {
         return internalServerError('Failed to read audit policy');
       }
       const current = row ? AuditPolicyDto.toJSON(row) : AuditPolicyDto.defaultDocument(siteId);
-      const newArray = computeNewArray(current[config.field], body.values, mode);
+      const normalize = resourceKey === 'exclusions'
+        ? (v) => normalizeExclusionGlob(site.getBaseURL(), v)
+        : (v) => v;
+      const newArray = computeNewArray(current[config.field], body.values, mode, normalize);
       if (newArray.length > config.max) {
         return badRequest(`${config.field} would exceed the maximum of ${config.max}`);
       }

--- a/src/controllers/audit-policy.js
+++ b/src/controllers/audit-policy.js
@@ -241,11 +241,10 @@ export default function AuditPolicyController() {
   // exclusion_glob_rewrite.sql:102-119) so the controller's own dedup compares
   // against the same representation the RPC will persist. Defense-in-depth only
   // (SITES-51200 item 2) — the RPC's own post-rewrite dedup (SITES-51200 item 1)
-  // remains the canonical guarantee against a stored duplicate.
+  // remains the canonical guarantee against a stored duplicate. No non-string
+  // guard: validateMutateBody already rejects non-string `values` entries, and
+  // stored exclusionGlobs are always strings coming out of AuditPolicyDto.
   function normalizeExclusionGlob(baseURL, value) {
-    if (typeof value !== 'string') {
-      return value;
-    }
     if (value === '' || value.startsWith('http://') || value.startsWith('https://') || value.startsWith('*')) {
       return value;
     }

--- a/test/controllers/audit-policy.test.js
+++ b/test/controllers/audit-policy.test.js
@@ -63,7 +63,7 @@ function buildContext({
     data,
     attributes: { authInfo: { getProfile: () => profile } },
     dataAccess: {
-      Site: { findById: sinon.stub().resolves({ getId: () => SITE_ID }) },
+      Site: { findById: sinon.stub().resolves({ getId: () => SITE_ID, getBaseURL: () => 'https://example.com' }) },
       services: { postgrestClient: client || buildClient() },
     },
     log: {
@@ -527,6 +527,67 @@ describe('AuditPolicyController — exclusions add/remove', () => {
     expect(res.status).to.equal(200);
     expect(client.rpc).to.have.been.calledWith(UPSERT_RPC, sinon.match({
       p_exclusion_globs: ['/checkout/*'],
+    }));
+  });
+
+  it('add: submitting the fully-qualified equivalent of an already-stored bare-path glob is deduped against the RPC-normalized value (SITES-51200 defense in depth)', async () => {
+    const client = buildSequencedClient({
+      selectQueue: [{ data: ROW_V5, error: null }],
+      rpcQueue: [{ data: { ...ROW_V5, version: 6 }, error: null }],
+    });
+    const controller = loadController();
+    await controller.addExclusions(buildContext({
+      client, data: { values: ['https://example.com/checkout/*'], reason: 'cross-representation no-op add' },
+    }));
+    expect(client.rpc).to.have.been.calledWith(UPSERT_RPC, sinon.match({
+      p_exclusion_globs: ['/checkout/*'],
+    }));
+    expect(client.rpc).to.have.been.calledOnce;
+  });
+
+  it('add: submitting the bare-path equivalent of an already-stored fully-qualified glob is deduped (reverse direction)', async () => {
+    const row = { ...ROW_V5, exclusion_globs: ['https://example.com/checkout/*'] };
+    const client = buildSequencedClient({
+      selectQueue: [{ data: row, error: null }],
+      rpcQueue: [{ data: { ...row, version: 6 }, error: null }],
+    });
+    const controller = loadController();
+    await controller.addExclusions(buildContext({
+      client, data: { values: ['/checkout/*'], reason: 'reverse cross-representation no-op add' },
+    }));
+    expect(client.rpc).to.have.been.calledWith(UPSERT_RPC, sinon.match({
+      p_exclusion_globs: ['https://example.com/checkout/*'],
+    }));
+    expect(client.rpc).to.have.been.calledOnce;
+  });
+
+  it('remove: a fully-qualified value removes an already-stored bare-path equivalent (normalized set-difference)', async () => {
+    const row = { ...ROW_V5, exclusion_globs: ['/checkout/*', '/account/*'] };
+    const client = buildSequencedClient({
+      selectQueue: [{ data: row, error: null }],
+      rpcQueue: [{ data: { ...row, version: 6, exclusion_globs: ['/account/*'] }, error: null }],
+    });
+    const controller = loadController();
+    const res = await controller.removeExclusions(buildContext({
+      client, data: { values: ['https://example.com/checkout/*'], reason: 'cross-representation remove' },
+    }));
+    expect(res.status).to.equal(200);
+    expect(client.rpc).to.have.been.calledWith(UPSERT_RPC, sinon.match({
+      p_exclusion_globs: ['/account/*'],
+    }));
+  });
+
+  it('add: a wildcard-prefixed glob is treated as a plain distinct entry, unaffected by normalization', async () => {
+    const client = buildSequencedClient({
+      selectQueue: [{ data: ROW_V5, error: null }],
+      rpcQueue: [{ data: { ...ROW_V5, version: 6 }, error: null }],
+    });
+    const controller = loadController();
+    await controller.addExclusions(buildContext({
+      client, data: { values: ['*/legacy/**'], reason: 'wildcard glob add' },
+    }));
+    expect(client.rpc).to.have.been.calledWith(UPSERT_RPC, sinon.match({
+      p_exclusion_globs: ['/checkout/*', '*/legacy/**'],
     }));
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Makes the audit-policy controller's client-side exclusion-glob dedup compare values by the same representation `wrpc_upsert_audit_policy` will persist, instead of comparing the raw caller/stored strings.

## 2. Reasoning
SITES-51200 root-caused a defect where two exclusion globs that are equivalent after the RPC's write-time glob rewrite (bare path vs. fully-qualified URL onto the site's `base_url`) could both be added, because the controller's own union/difference dedup runs on the raw values *before* that rewrite happens. The RPC-side canonical fix (item 1 of the ticket — a post-rewrite dedup inside `wrpc_upsert_audit_policy`) is already merged in `mysticat-data-service` PR #1036, so no stored duplicate can persist anymore. This PR is item 2, "defense in depth": it also fixes the controller so its own pre-RPC array — and the `newArray.length > max` cap check that runs against it — reflect the true deduped state rather than over-counting representations the RPC would collapse anyway.

## 3. High-level overview of the changes
- `src/controllers/audit-policy.js` gains `normalizeExclusionGlob(baseURL, value)`, a JS mirror of the exact CASE rewrite `wrpc_upsert_audit_policy` applies at write time (pass through empty/`http(s)://`/`*`-prefixed values unchanged; otherwise root the value onto the site's `base_url`, handling the leading-`/` vs. relative-path split).
- `computeNewArray` now takes a `normalize` function and keys its add-side union / remove-side difference off the *normalized* value, while still preserving the original raw string in the array it returns (order-preserving, first occurrence wins — same external contract as before).
- `mutateArray` builds that `normalize` function per call: for the `exclusions` resource it's `normalizeExclusionGlob(site.getBaseURL(), v)` (site's base URL fetched lazily, only on this path); for `inclusions` (manualUrls) it stays identity, since the RPC never rewrites manual URLs.
- Net behavior change: submitting an exclusion glob that is a different-but-equivalent representation of one already on the policy (e.g. `/checkout/*` when `https://example.com/checkout/*` is already stored, or vice versa) is now treated as the existing element for add (no-op, no new entry) and for remove (it is matched and removed) — matching what the RPC will actually do to the array, and giving the cap check an accurate count before the RPC call even happens.
- `inclusions` (manualUrls) behavior is unchanged.

## 4. Required information
- Jira / issue: [SITES-51200](https://jira.corp.adobe.com/browse/SITES-51200)
- Other: mysticat-data-service PR #1036 (item 1, the canonical RPC-side post-rewrite dedup, already merged); [platform/design-audit-policy-exclusion-glob-write-normalization.md](https://github.com/adobe/mysticat-architecture/blob/main/platform/design-audit-policy-exclusion-glob-write-normalization.md) (mysticat-architecture — documents the RPC's write-time rewrite rule this PR mirrors in JS; SITES-51200 itself has no dedicated spec doc)

## 6. Affected / used mysticat-workspace projects
- mysticat-data-service: contract dependency only (not changed here). This PR's `normalizeExclusionGlob` intentionally duplicates the rewrite rule already implemented in `wrpc_upsert_audit_policy` (db/migrations/20260814154830_audit_policy_exclusion_glob_rewrite.sql:102-119). If that rewrite rule ever changes, this JS copy must be updated to match or the two will silently disagree — see the accepted logic-drift risk below.

## 8. Test plan
(a) No new local e2e/manual run was performed for this change — it's a pure controller-logic fix fully exercised by the unit suite, so an e2e pass would not add signal beyond what the unit tests already assert.
(b) Manual verification on any environment (dev/stage/prod), if desired: call `POST /audit-policy/:siteId/exclusions` (add) twice for the same site — once with a bare-path glob (e.g. `/checkout/*`) and once with its fully-qualified equivalent (`https://<site-base-url>/checkout/*`) — and confirm the second call returns the same `exclusionGlobs` array with no new entry added (previously it would have added a duplicate entry client-side before the RPC's own — separately fixed — dedup collapsed it server-side).

Note: this PR intentionally duplicates the RPC's write-time normalization logic in JS — an accepted logic-drift risk versus the single canonical implementation in `wrpc_upsert_audit_policy`, per the ticket's own item 2. The RPC's post-rewrite dedup (item 1, already merged) remains the actual source of truth for what gets persisted; this controller-side change is a client-side reflect-reality / cap-accuracy improvement only, not a correctness requirement.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Client-side defense-in-depth mirror of an already-merged RPC-side normalization fix; no destructive data path, reversible by redeploy."
```