### PR TITLE
ci: enable shared push/PR heavy-path dedup on api-service CI (dedup-pr-runs)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,19 +28,26 @@ on:
 
 jobs:
   # The reusable CI runs on both `push` and `pull_request`, so for an open PR its
-  # `build` + `it-postgres` run twice per commit (the concurrency group keys on
-  # `github.ref`, which differs between the two events, so they don't cancel each
-  # other). That duplication is deliberate here: the `push` run uniquely carries
-  # the reusable `branch-deploy` job, which auto-deploys feature branches to the
-  # `dev-branches` env and fires on push only. A previous attempt to skip the
-  # non-main `push` run to dedup (this repo's #3235) silently disabled that. A real
-  # dedup that keeps branch-deploy needs a change in the shared service-ci workflow
-  # (tracked in the mysticat-ci CI-queue issue), not a caller-side push skip.
+  # `build` + `it-postgres` would run twice per commit (the concurrency group keys
+  # on `github.ref`, which differs between the two events, so they don't cancel
+  # each other). `dedup-pr-runs: true` makes the shared service-ci workflow skip
+  # the redundant `pull_request` copy of that heavy path for a same-repo PR: the
+  # branch's `push` run covers the same head SHA and reports the required
+  # `ci / build` + `ci / it-postgres`, so the `pull_request` copies come back
+  # `skipped` and branch protection is satisfied by the push run.
   #
-  # The one caller-side saving kept: skip the `pull_request` copy on DRAFT PRs. A
-  # draft can't merge, the `push` run still runs branch-deploy and reports the
-  # required `ci / build` + `ci / it-postgres` on the same commit, and
-  # `ready_for_review` re-triggers the full `pull_request` run.
+  # The `push` run is NEVER the one skipped, so `branch-deploy` (push-only,
+  # auto-deploys feature branches to `dev-branches`) is preserved. Skipping the
+  # push run instead is exactly what this repo's #3235 did — silently disabling
+  # branch-deploy — which the shared dedup is designed to avoid. Fork PRs still
+  # run the heavy path on `pull_request` (they have no base-repo push twin). See
+  # mysticat-ci `.github/actions/ci-context/README.md`.
+  #
+  # The caller-side DRAFT-PR skip is kept and composes with the above: a draft PR
+  # skips the whole `pull_request` `ci` job (the `push` run still covers the
+  # required checks and runs branch-deploy), and `ready_for_review` re-triggers
+  # the `pull_request` run — where the shared dedup then skips only build +
+  # it-postgres.
   ci:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: adobe/mysticat-ci/.github/workflows/service-ci.yaml@v3
@@ -51,6 +58,7 @@ jobs:
       it-postgres: true
       vpc-enabled: true
       bundle-build: true
+      dedup-pr-runs: true
     secrets: inherit
 
   # Opt-in TypeScript type-checking (checkJs + JSDoc, no .ts source) over the


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Enables the shared push/PR heavy-path dedup on this repo's CI by setting `dedup-pr-runs: true` on the `adobe/mysticat-ci` `service-ci@v3` reusable workflow.

## 2. Reasoning
For an open same-repo PR, this repo's CI runs the heavy path (`build` + `it-postgres`, each ~5-7 min and the branch-protection required checks) **twice per commit**: once on the `push` event and once on `pull_request`. `service-ci` runs on both events, and its `concurrency` group keys on `github.ref` (which differs between the two), so the runs never cancel each other. That doubles the runner-slot pressure this repo puts on the shared `adobe`-org pool on every commit of every PR.

A caller-side push-skip is not a safe fix - this repo's #3235 tried it and silently disabled `branch-deploy` (which fires on `push` only). `adobe/mysticat-ci` v3.3.0 shipped an opt-in dedup that skips only the redundant same-repo `pull_request` copy of the heavy path while never touching the `push` run. This PR turns it on.

## 3. High-level overview of the changes
One-line workflow change (`dedup-pr-runs: true`), plus a refresh of the now-stale caller comment that said an upstream dedup was still pending.

Behaviour delta for an open **same-repo** PR:
- Before: `build` + `it-postgres` run on both the `push` and the `pull_request` event - twice per commit.
- After: they run once. The shared workflow skips the `pull_request` copy; the branch's `push` run covers the same head SHA and reports the required `ci / build` + `ci / it-postgres`. The `pull_request` copies surface as `skipped`, which branch protection treats as satisfied because the push run's success is on the same commit.

Unchanged:
- `branch-deploy` (push-only feature-branch auto-deploy to `dev-branches`) - the `push` run is never the one skipped.
- Fork PRs - they have no base-repo `push` twin, so they still run the heavy path on `pull_request`.
- The caller-side DRAFT-PR skip - it composes with the shared dedup (draft skips the whole `pull_request` `ci` job; a ready PR runs it with `build` + `it-postgres` deduped).

Operationally visible: on a PR check page, `ci / build` + `ci / it-postgres` will show as `skipped` on the `pull_request` run and green on the `push` run. That is the intended state, not a failure.

## 4. Required information
- Other: shared mechanism `adobe/mysticat-ci` PR https://github.com/adobe/mysticat-ci/pull/26 ; release https://github.com/adobe/mysticat-ci/releases/tag/v3.3.0 ; design + rollout doc https://github.com/adobe/mysticat-ci/blob/v3.3.0/.github/actions/ci-context/README.md

## 6. Affected / used mysticat-workspace projects
- `adobe/mysticat-ci` (contract dependency): this repo consumes `service-ci.yaml@v3`; the `dedup-pr-runs` input it now passes was shipped in mysticat-ci v3.3.0 and the floating `v3` tag has been moved to include it. No further mysticat-ci change is required.

## 7. Additional information outside the code
Rollout prerequisites for enabling the dedup on this repo (from the mysticat-ci ci-context rollout gate) were verified this session before opening this PR:
- Branch-protection required status checks on `main` are exactly `ci / build` and `ci / it-postgres` - the two heavy jobs the dedup skips on the `pull_request` copy (`gh api repos/adobe/spacecat-api-service/branches/main/protection/required_status_checks`).
- This repo's `ci.yaml` runs `service-ci` on unfiltered `push:` (all branches), so a same-repo PR always has a covering `push` run that reports those checks on the head SHA and carries `branch-deploy`.
- `strict: false`, so there is no require-branches-up-to-date rerun churn.
- The shared mechanism is regression-guarded upstream: mysticat-ci's `test-service-ci-dedup.sh` T4/T5 (mutation-tested) fail closed if `branch-deploy`'s push gate is ever removed, and the heavy `if:` is exact-string-pinned against drift.

## 8. Test plan
(a) Local: this is a workflow-config change; validated that `ci.yaml` parses and that the input name matches the input shipped in mysticat-ci v3.3.0 (`dedup-pr-runs`). An unknown input would fail the caller immediately.

(b) On this PR (this is itself the first-live-PR verification the rollout gate calls for): confirm that `ci / build` and `ci / it-postgres` report **green from the `push` run** while the `pull_request` copies show `skipped`, that `branch-deploy` runs on the push, and that the PR's required checks are satisfied (mergeable). If a required check instead hangs `pending`, the push run is not reporting on the PR head SHA for this repo - remove the one input line and investigate before relying on it. No dev/stage/prod verification applies (CI-only change; no service code or deploy behaviour changes).

## 9. Deployment & merge order
This depended on the shared mechanism landing first: `adobe/mysticat-ci#26` merged and released as v3.3.0, with the floating `v3` tag moved to include the `dedup-pr-runs` input. Both are already done, so this PR is now independent and safe to merge on its own.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "CI-only change: turns on the opt-in shared push/PR heavy-path dedup (mysticat-ci v3.3.0) for this repo by passing one reusable-workflow input. No service code, no deploy behaviour, branch-deploy preserved. The upstream mechanism (mysticat-ci#26) is already merged and released."
recommendations: "This PR is itself the first-live-PR verification: confirm ci / build and ci / it-postgres go green from the push run (pull_request copies skipped) before merging."
backout: "Revert the commit (remove dedup-pr-runs: true); CI returns to running the heavy path on both push and pull_request."
```
