### PR TITLE
fix(llmo): fall back to DRS on any Semrush prompts-by-url failure

### DIFF
--- a/src/controllers/llmo/llmo-url-inspector.js
+++ b/src/controllers/llmo/llmo-url-inspector.js
@@ -810,6 +810,14 @@ export function createUrlInspectorPromptsByUrlHandler(
       const startDate = params.startDate || defaults.startDate;
       const endDate = params.endDate || defaults.endDate;
 
+      const fetchViaMysticat = () => (urlId
+        ? fetchUrlPromptsViaMysticat(client, ctx.log, {
+          siteId: params.siteId, urlId, startDate, endDate, model,
+        })
+        : fetchUrlPromptsByUrlViaMysticat(client, ctx.log, {
+          siteId: params.siteId, url, startDate, endDate, model,
+        }));
+
       // Falls back to the Mysticat branch (rather than propagating) if
       // eligibility resolution itself throws (e.g. Brand/Organization
       // data-access unavailable, or a DB read error).
@@ -838,19 +846,18 @@ export function createUrlInspectorPromptsByUrlHandler(
           });
           return cachedOk({ prompts });
         } catch (e) {
+          // Semrush unreachable/unauthorized/erroring for this eligible brand
+          // (e.g. an S2S caller with no IMS user token to forward — see
+          // resolveSemrushImsToken) — fall back to the DRS/mysticat RPC below
+          // instead of failing the request. Previously this masked every
+          // failure, including a legitimate 401, as a generic 500; falling
+          // back to real (DRS) data is strictly better than either.
           const statusPart = e?.status ? ` [status=${e.status}]` : '';
-          ctx.log.error(`URL Inspector prompts-by-url Semrush error: ${e?.message || e}${statusPart}`);
-          return internalServerError('Internal error processing URL Inspector prompts');
+          ctx.log.warn(`URL Inspector prompts-by-url Semrush error, falling back to DRS: ${e?.message || e}${statusPart}`);
         }
       }
 
-      const result = urlId
-        ? await fetchUrlPromptsViaMysticat(client, ctx.log, {
-          siteId: params.siteId, urlId, startDate, endDate, model,
-        })
-        : await fetchUrlPromptsByUrlViaMysticat(client, ctx.log, {
-          siteId: params.siteId, url, startDate, endDate, model,
-        });
+      const result = await fetchViaMysticat();
       if (result.error) {
         return result.error;
       }

--- a/src/controllers/llmo/llmo-url-inspector.js
+++ b/src/controllers/llmo/llmo-url-inspector.js
@@ -810,14 +810,6 @@ export function createUrlInspectorPromptsByUrlHandler(
       const startDate = params.startDate || defaults.startDate;
       const endDate = params.endDate || defaults.endDate;
 
-      const fetchViaMysticat = () => (urlId
-        ? fetchUrlPromptsViaMysticat(client, ctx.log, {
-          siteId: params.siteId, urlId, startDate, endDate, model,
-        })
-        : fetchUrlPromptsByUrlViaMysticat(client, ctx.log, {
-          siteId: params.siteId, url, startDate, endDate, model,
-        }));
-
       // Falls back to the Mysticat branch (rather than propagating) if
       // eligibility resolution itself throws (e.g. Brand/Organization
       // data-access unavailable, or a DB read error).
@@ -846,18 +838,20 @@ export function createUrlInspectorPromptsByUrlHandler(
           });
           return cachedOk({ prompts });
         } catch (e) {
-          // Semrush unreachable/unauthorized/erroring for this eligible brand
-          // (e.g. an S2S caller with no IMS user token to forward — see
-          // resolveSemrushImsToken) — fall back to the DRS/mysticat RPC below
-          // instead of failing the request. Previously this masked every
-          // failure, including a legitimate 401, as a generic 500; falling
-          // back to real (DRS) data is strictly better than either.
+          // Semrush failed (e.g. an S2S caller has no IMS token to forward) — fall
+          // back to the DRS/mysticat RPC below instead of failing the request.
           const statusPart = e?.status ? ` [status=${e.status}]` : '';
           ctx.log.warn(`URL Inspector prompts-by-url Semrush error, falling back to DRS: ${e?.message || e}${statusPart}`);
         }
       }
 
-      const result = await fetchViaMysticat();
+      const result = urlId
+        ? await fetchUrlPromptsViaMysticat(client, ctx.log, {
+          siteId: params.siteId, urlId, startDate, endDate, model,
+        })
+        : await fetchUrlPromptsByUrlViaMysticat(client, ctx.log, {
+          siteId: params.siteId, url, startDate, endDate, model,
+        });
       if (result.error) {
         return result.error;
       }

--- a/test/controllers/llmo/llmo-url-inspector.test.js
+++ b/test/controllers/llmo/llmo-url-inspector.test.js
@@ -1795,16 +1795,19 @@ describe('URL Inspector Handlers', () => {
       expect(body.prompts[0].citations).to.equal(0);
     });
 
-    it('returns internalServerError when the Semrush service throws a non-Error value', async () => {
+    it('falls back to Mysticat when the Semrush service throws a non-Error value', async () => {
       // eslint-disable-next-line prefer-promise-reject-errors -- covers e?.message||e fallback
       getUrlPromptsStub.callsFake(() => Promise.reject('semrush boom'));
-      const { context } = createContext(
+      const { context, rpcStub } = createContext(
         { brandId: BRAND_UUID },
         { url: 'https://example.com/a' },
       );
       const handler = createUrlInspectorPromptsByUrlHandler(getOrgAndValidateAccess());
       const response = await handler(context);
-      expect(response.status).to.equal(500);
+      expect(response.status).to.equal(200);
+      expect(rpcStub).to.have.been.calledWith('rpc_url_inspector_prompts_by_url', sinon.match({
+        p_url: 'https://example.com/a',
+      }));
     });
 
     it('returns forbidden when site does not belong to org', async () => {
@@ -1989,31 +1992,37 @@ describe('URL Inspector Handlers', () => {
       expect(context.log.error.firstCall.args[0]).to.include('sub-workspace equals org parent workspace');
     });
 
-    it('returns internalServerError when the Semrush service call throws', async () => {
+    it('falls back to Mysticat when the Semrush service call throws', async () => {
       getUrlPromptsStub.rejects(new Error('semrush boom'));
-      const { context } = createContext(
+      const { context, rpcStub } = createContext(
         { brandId: BRAND_UUID },
         { url: 'https://example.com/a' },
       );
       const handler = createUrlInspectorPromptsByUrlHandler(getOrgAndValidateAccess());
       const response = await handler(context);
-      expect(response.status).to.equal(500);
+      expect(response.status).to.equal(200);
+      expect(rpcStub).to.have.been.calledWith('rpc_url_inspector_prompts_by_url', sinon.match({
+        p_url: 'https://example.com/a',
+      }));
     });
 
-    it('logs the status code when the Semrush call throws an ErrorWithStatusCode', async () => {
+    it('falls back to Mysticat and logs the status code when the Semrush call throws an ErrorWithStatusCode (e.g. 401 for a non-IMS caller)', async () => {
       const err = new Error('Invalid or expired promise token');
       err.status = 401;
       getUrlPromptsStub.rejects(err);
-      const { context } = createContext(
+      const { context, rpcStub } = createContext(
         { brandId: BRAND_UUID },
         { url: 'https://example.com/a' },
       );
       const handler = createUrlInspectorPromptsByUrlHandler(getOrgAndValidateAccess());
       const response = await handler(context);
 
-      expect(response.status).to.equal(500);
-      expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Invalid or expired promise token.*\[status=401\]/),
+      expect(response.status).to.equal(200);
+      expect(rpcStub).to.have.been.calledWith('rpc_url_inspector_prompts_by_url', sinon.match({
+        p_url: 'https://example.com/a',
+      }));
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/falling back to DRS.*Invalid or expired promise token.*\[status=401\]/i),
       );
     });
 


### PR DESCRIPTION
## Summary
- The Semrush branch of `prompts-by-url` (`llmo-url-inspector.js`) previously masked every failure (auth, transport, upstream error) as a generic `500 internalServerError` — including a legitimate 401 when the caller can't forward an IMS user token (e.g. an S2S caller, which has no route to satisfy `resolveSemrushImsToken`).
- Falls back to the existing DRS/mysticat RPC path on any Semrush-path error instead of failing the request, matching the same response shape already used for ineligible brands.
- This is Phase 0 + Phase 1 of the LLMO-5789 plan to have mystique pass the real `brand_id` (instead of always `"all"`) so eligible brands route to Semrush — this fallback makes that safe today even though there's currently no S2S auth path to Semrush (see [LLMO-6836](https://jira.corp.adobe.com/browse/LLMO-6836), tracked separately).

## Test plan
- [x] Updated 3 existing unit tests that asserted the old "throws → 500" behavior to assert the new DRS fallback instead
- [x] `npx mocha test/controllers/llmo/llmo-url-inspector.test.js` — 108/108 passing
- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Replaces a hard 500 with an existing DRS fallback path on upstream failure; small, reversible by redeploy."
```