### PR TITLE
fix(brands): sanitize and bound brand-claims guidance input (LLMO-7450)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -35,6 +35,7 @@ import {
 
 import { ErrorWithStatusCode, getImsUserToken, resolveSemrushImsToken } from '../support/utils.js';
 import { hostnameFromUrlString } from '../support/url-utils.js';
+import { BRAND_GUIDANCE_MAX_LENGTH, codePointLength } from '../support/brand-guidance.js';
 import {
   STATUS_BAD_REQUEST,
 } from '../utils/constants.js';
@@ -119,7 +120,6 @@ import {
 } from '../support/topics-storage.js';
 
 const HEADER_ERROR = 'x-error';
-const BRAND_GUIDANCE_MAX_LENGTH = 4000;
 const BRAND_GUIDANCE_FIELDS = ['brandContext', 'mentionSentimentGuidance'];
 
 /**
@@ -400,9 +400,11 @@ function BrandsController(ctx, log, env) {
         if (typeof value !== 'string') {
           return badRequest(`${field} must be a string or null`);
         }
-        // Validate the trimmed length: storage trims before persisting, so this
-        // mirrors what is actually stored (and the schema's maxLength).
-        if (value.trim().length > BRAND_GUIDANCE_MAX_LENGTH) {
+        // Validate the trimmed length in code points: storage trims before persisting,
+        // so this mirrors what is actually stored, and code-point counting matches the
+        // storage backstop (codePointLength) so both layers agree on "4000 characters"
+        // for non-BMP input (e.g. emoji count as one, not two UTF-16 units).
+        if (codePointLength(value.trim()) > BRAND_GUIDANCE_MAX_LENGTH) {
           return badRequest(`${field} must be at most ${BRAND_GUIDANCE_MAX_LENGTH} characters`);
         }
       }

--- a/src/support/brand-guidance.js
+++ b/src/support/brand-guidance.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Shared sanitization + limit for the brand-claims guidance free-text fields
+ * (brandContext, mentionSentimentGuidance). Kept in one place so every path that
+ * persists guidance — the storage write path (brands-storage.js) and the V1->V2
+ * config migration (customer-config-mapper.js) — strips the same characters and
+ * agrees on the same length, and so the controller (brands.js) validates against
+ * the same limit it is enforcing.
+ */
+
+/**
+ * The customer-facing "characters" limit for a single guidance field. Measured in
+ * Unicode code points (see codePointLength), so one emoji counts as one character.
+ */
+export const BRAND_GUIDANCE_MAX_LENGTH = 4000;
+
+/*
+ * Guidance is persisted verbatim and later interpolated into the Claims-extraction
+ * LLM prompt, so we strip characters that carry no legitimate meaning in guidance
+ * prose but can corrupt the prompt, downstream logs/terminals, or a bidi-aware
+ * renderer:
+ *   - C0 control chars except tab/newline/carriage-return (U+0000-U+001F minus \t\n\r)
+ *   - DEL and the C1 control block (U+007F-U+009F)
+ *   - zero-width / word-joiner / BOM (U+200B-U+200D, U+2060, U+FEFF)
+ *   - line/paragraph separators (U+2028, U+2029) — break JSON-embedded-in-JS and forge log lines
+ *   - bidirectional override & isolate controls -- the "Trojan Source" class
+ *     (U+202A-U+202E, U+2066-U+2069)
+ * Ordinary whitespace and all printable Unicode (incl. RTL letters, accents, emoji)
+ * are preserved, so this is language-safe. Notably we do NOT strip lone surrogates
+ * (U+D800-U+DFFF) here: without the RegExp `u` flag that range also matches each half
+ * of a legitimate surrogate pair, which would delete every emoji / astral-plane
+ * character. This is defense-in-depth, not a substitute for treating the stored text
+ * as untrusted at prompt-assembly time (prompt-injection is owned by the LLM template).
+ */
+export const UNSAFE_TEXT_CHARS = new RegExp(
+  '[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F-\\u009F'
+  + '\\u200B-\\u200D\\u2060\\uFEFF\\u2028\\u2029\\u202A-\\u202E\\u2066-\\u2069]',
+  'g',
+);
+
+/**
+ * Strip the unsafe control/invisible/bidi characters above from a string.
+ * @param {string} value
+ * @returns {string}
+ */
+export function sanitizeGuidanceText(value) {
+  return value.replace(UNSAFE_TEXT_CHARS, '');
+}
+
+/**
+ * Length of a string in Unicode code points (not UTF-16 code units), so a non-BMP
+ * character (emoji, some CJK) counts as one. Both the controller and the storage
+ * backstop measure the guidance limit this way so they agree on what "4000
+ * characters" means for astral input.
+ * @param {string} value
+ * @returns {number}
+ */
+export function codePointLength(value) {
+  return [...value].length;
+}

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -13,6 +13,11 @@
 import { composeBaseURL, hasText } from '@adobe/spacecat-shared-utils';
 
 import { SERENITY_BRAND_SITE_TYPE } from './serenity/site-linkage.js';
+import {
+  BRAND_GUIDANCE_MAX_LENGTH,
+  codePointLength,
+  sanitizeGuidanceText,
+} from './brand-guidance.js';
 import { readFeatureFlagScopes, resolveFlagRowForBrand } from './feature-flags-storage.js';
 import {
   SERENITY_FEATURE_FLAG_NAME,
@@ -53,40 +58,6 @@ function rethrowCheckViolation(error, fallbackMessage) {
   throw new Error(fallbackMessage);
 }
 
-/*
- * Free-text guidance fields (brandContext, mentionSentimentGuidance) are persisted
- * verbatim and later interpolated into the Claims-extraction LLM prompt, so we strip
- * characters that carry no legitimate meaning in guidance prose but can corrupt the
- * prompt, downstream logs/terminals, or a bidi-aware renderer:
- *   - C0 control chars except tab/newline/carriage-return (U+0000-U+001F minus \t\n\r)
- *   - DEL and the C1 control block (U+007F-U+009F)
- *   - zero-width / word-joiner / BOM (U+200B-U+200D, U+2060, U+FEFF)
- *   - line/paragraph separators (U+2028, U+2029) — break JSON-embedded-in-JS and forge log lines
- *   - bidirectional override & isolate controls -- the "Trojan Source" class
- *     (U+202A-U+202E, U+2066-U+2069)
- * Ordinary whitespace and all printable Unicode (incl. RTL letters, accents, emoji)
- * are preserved, so this is language-safe. Notably we do NOT strip lone surrogates
- * (U+D800-U+DFFF) here: without the RegExp `u` flag that range also matches each half
- * of a legitimate surrogate pair, which would delete every emoji / astral-plane
- * character. This is defense-in-depth, not a substitute for treating the stored text
- * as untrusted at prompt-assembly time (prompt-injection is owned by the LLM template).
- */
-const UNSAFE_TEXT_CHARS = new RegExp(
-  '[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F-\\u009F'
-  + '\\u200B-\\u200D\\u2060\\uFEFF\\u2028\\u2029\\u202A-\\u202E\\u2066-\\u2069]',
-  'g',
-);
-
-// Defense-in-depth cap at the persistence boundary, mirroring the controller's
-// validateBrandGuidanceFields. buildBrandRow/updateBrand are exported and can be
-// reached without the controller; without this backstop such a caller could persist
-// unbounded text straight into the DB and the Claims-extraction prompt.
-const GUIDANCE_MAX_LENGTH = 4000;
-
-function sanitizeGuidanceText(value) {
-  return value.replace(UNSAFE_TEXT_CHARS, '');
-}
-
 function normalizeNullableText(value, fieldName) {
   if (value === undefined) {
     return undefined;
@@ -104,10 +75,12 @@ function normalizeNullableText(value, fieldName) {
   // Strip unsafe control/invisible/bidi chars before trimming so leading/trailing
   // whitespace exposed by their removal is also collapsed to null.
   const trimmed = sanitizeGuidanceText(value).trim();
-  // Length is measured on the sanitized+trimmed value (what is actually stored),
-  // using spread so an astral character straddling the boundary is counted as one.
-  if ([...trimmed].length > GUIDANCE_MAX_LENGTH) {
-    const error = new Error(`${fieldName} must be at most ${GUIDANCE_MAX_LENGTH} characters`);
+  // Defense-in-depth cap at the persistence boundary, mirroring the controller's
+  // validateBrandGuidanceFields (both measure code points via codePointLength, so they
+  // agree on the limit). buildBrandRow/updateBrand are exported and reachable without
+  // the controller; without this backstop such a caller could persist unbounded text.
+  if (codePointLength(trimmed) > BRAND_GUIDANCE_MAX_LENGTH) {
+    const error = new Error(`${fieldName} must be at most ${BRAND_GUIDANCE_MAX_LENGTH} characters`);
     error.status = 400;
     throw error;
   }

--- a/src/support/brands-storage.js
+++ b/src/support/brands-storage.js
@@ -53,6 +53,40 @@ function rethrowCheckViolation(error, fallbackMessage) {
   throw new Error(fallbackMessage);
 }
 
+/*
+ * Free-text guidance fields (brandContext, mentionSentimentGuidance) are persisted
+ * verbatim and later interpolated into the Claims-extraction LLM prompt, so we strip
+ * characters that carry no legitimate meaning in guidance prose but can corrupt the
+ * prompt, downstream logs/terminals, or a bidi-aware renderer:
+ *   - C0 control chars except tab/newline/carriage-return (U+0000-U+001F minus \t\n\r)
+ *   - DEL and the C1 control block (U+007F-U+009F)
+ *   - zero-width / word-joiner / BOM (U+200B-U+200D, U+2060, U+FEFF)
+ *   - line/paragraph separators (U+2028, U+2029) — break JSON-embedded-in-JS and forge log lines
+ *   - bidirectional override & isolate controls -- the "Trojan Source" class
+ *     (U+202A-U+202E, U+2066-U+2069)
+ * Ordinary whitespace and all printable Unicode (incl. RTL letters, accents, emoji)
+ * are preserved, so this is language-safe. Notably we do NOT strip lone surrogates
+ * (U+D800-U+DFFF) here: without the RegExp `u` flag that range also matches each half
+ * of a legitimate surrogate pair, which would delete every emoji / astral-plane
+ * character. This is defense-in-depth, not a substitute for treating the stored text
+ * as untrusted at prompt-assembly time (prompt-injection is owned by the LLM template).
+ */
+const UNSAFE_TEXT_CHARS = new RegExp(
+  '[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F-\\u009F'
+  + '\\u200B-\\u200D\\u2060\\uFEFF\\u2028\\u2029\\u202A-\\u202E\\u2066-\\u2069]',
+  'g',
+);
+
+// Defense-in-depth cap at the persistence boundary, mirroring the controller's
+// validateBrandGuidanceFields. buildBrandRow/updateBrand are exported and can be
+// reached without the controller; without this backstop such a caller could persist
+// unbounded text straight into the DB and the Claims-extraction prompt.
+const GUIDANCE_MAX_LENGTH = 4000;
+
+function sanitizeGuidanceText(value) {
+  return value.replace(UNSAFE_TEXT_CHARS, '');
+}
+
 function normalizeNullableText(value, fieldName) {
   if (value === undefined) {
     return undefined;
@@ -67,7 +101,16 @@ function normalizeNullableText(value, fieldName) {
     error.status = 400;
     throw error;
   }
-  const trimmed = value.trim();
+  // Strip unsafe control/invisible/bidi chars before trimming so leading/trailing
+  // whitespace exposed by their removal is also collapsed to null.
+  const trimmed = sanitizeGuidanceText(value).trim();
+  // Length is measured on the sanitized+trimmed value (what is actually stored),
+  // using spread so an astral character straddling the boundary is counted as one.
+  if ([...trimmed].length > GUIDANCE_MAX_LENGTH) {
+    const error = new Error(`${fieldName} must be at most ${GUIDANCE_MAX_LENGTH} characters`);
+    error.status = 400;
+    throw error;
+  }
   return hasText(trimmed) ? trimmed : null;
 }
 

--- a/src/support/customer-config-mapper.js
+++ b/src/support/customer-config-mapper.js
@@ -12,6 +12,7 @@
 
 import { hasText, isNonEmptyObject } from '@adobe/spacecat-shared-utils';
 import crypto from 'crypto';
+import { BRAND_GUIDANCE_MAX_LENGTH, sanitizeGuidanceText } from './brand-guidance.js';
 
 /**
  * Default verticals list for migration/initialization.
@@ -42,8 +43,6 @@ const DEFAULT_VERTICALS = [
   'Government & Public Services',
 ];
 
-const BRAND_GUIDANCE_MAX_LENGTH = 4000;
-
 function normalizeBrandGuidance(value) {
   if (value === undefined) {
     return undefined;
@@ -54,13 +53,17 @@ function normalizeBrandGuidance(value) {
   if (typeof value !== 'string') {
     return undefined;
   }
-  const trimmed = value.trim();
+  // Strip unsafe control/invisible/bidi chars, matching the storage write path
+  // (brands-storage.js) — this migration path writes via writeCustomerConfigV2ToPostgres,
+  // which does NOT route through normalizeNullableText, so it must sanitize here too.
+  const trimmed = sanitizeGuidanceText(value).trim();
   if (!hasText(trimmed)) {
     return null;
   }
   // Truncate on code-point boundaries (spread, not slice): a plain slice(0, n) counts
   // UTF-16 code units and can cut an emoji / non-BMP CJK char in half, leaving a lone
-  // surrogate that is invalid UTF-8 and breaks Postgres/JSON downstream.
+  // surrogate that is invalid UTF-8 and breaks Postgres/JSON downstream. This is a bulk
+  // migration path, so it truncates (rather than rejecting) to never hard-fail an import.
   const codePoints = [...trimmed];
   return codePoints.length > BRAND_GUIDANCE_MAX_LENGTH
     ? codePoints.slice(0, BRAND_GUIDANCE_MAX_LENGTH).join('')

--- a/src/support/customer-config-mapper.js
+++ b/src/support/customer-config-mapper.js
@@ -58,8 +58,12 @@ function normalizeBrandGuidance(value) {
   if (!hasText(trimmed)) {
     return null;
   }
-  return trimmed.length > BRAND_GUIDANCE_MAX_LENGTH
-    ? trimmed.slice(0, BRAND_GUIDANCE_MAX_LENGTH)
+  // Truncate on code-point boundaries (spread, not slice): a plain slice(0, n) counts
+  // UTF-16 code units and can cut an emoji / non-BMP CJK char in half, leaving a lone
+  // surrogate that is invalid UTF-8 and breaks Postgres/JSON downstream.
+  const codePoints = [...trimmed];
+  return codePoints.length > BRAND_GUIDANCE_MAX_LENGTH
+    ? codePoints.slice(0, BRAND_GUIDANCE_MAX_LENGTH).join('')
     : trimmed;
 }
 

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -6082,6 +6082,28 @@ describe('Brands Controller', () => {
       expect(response.status).to.equal(201);
     });
 
+    it('counts guidance length in code points, so 4000 emoji (8000 UTF-16 units) is accepted', async () => {
+      // Code-point counting matches the storage backstop; UTF-16 length would wrongly reject.
+      const response = await brandsController.createBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'New Brand', brandContext: '🚀'.repeat(4000) },
+        dataAccess: mockDataAccess,
+        attributes: { authInfo: { getType: () => 'ims', profile: { email: 'user@test.com' } } },
+      });
+      expect(response.status).to.equal(201);
+    });
+
+    it('rejects brand guidance longer than 4000 code points (4001 emoji)', async () => {
+      const response = await brandsController.createBrandForOrg({
+        ...context,
+        params: { spaceCatId: ORGANIZATION_ID },
+        data: { name: 'New Brand', brandContext: '🚀'.repeat(4001) },
+        dataAccess: mockDataAccess,
+      });
+      expect(response.status).to.equal(400);
+    });
+
     it('returns 400 when params is undefined', async () => {
       const response = await brandsController.createBrandForOrg({
         ...context,

--- a/test/support/brands-storage.test.js
+++ b/test/support/brands-storage.test.js
@@ -1343,6 +1343,53 @@ describe('brands-storage', () => {
       expect(caught.status).to.equal(400);
     });
 
+    it('strips control/invisible/bidi chars from brand guidance while keeping printable text', async () => {
+      // Good{U+202E bidi override}{U+200B zero-width}{NUL}{U+2028 line sep}text 🚀
+      const dirty = `Good${String.fromCharCode(0x202E)}${String.fromCharCode(0x200B)}`
+        + `${String.fromCharCode(0)}${String.fromCharCode(0x2028)}text 🚀`;
+      const client = createCapturingClient({
+        brands: [
+          { data: null, error: null },
+          { data: { id: BRAND_ID, name: 'Test' }, error: null },
+          {
+            data: makeBrandRow({ name: 'Test', brand_context: 'Goodtext 🚀' }),
+            error: null,
+          },
+        ],
+      });
+
+      await upsertBrand({
+        organizationId: ORG_ID,
+        brand: { name: 'Test', brandContext: dirty },
+        postgrestClient: client,
+      });
+
+      const brandsUpsert = client.capturedCalls.upsert.find((c) => c.table === 'brands');
+      // Bidi/zero-width/control/line-separator removed; letters, space and emoji preserved.
+      expect(brandsUpsert.row.brand_context).to.equal('Goodtext 🚀');
+    });
+
+    it('rejects brand guidance longer than 4000 chars with a 400-tagged error', async () => {
+      const client = createCapturingClient({
+        brands: [{ data: null, error: null }],
+      });
+
+      let caught;
+      try {
+        await upsertBrand({
+          organizationId: ORG_ID,
+          brand: { name: 'Test', mentionSentimentGuidance: 'a'.repeat(4001) },
+          postgrestClient: client,
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).to.be.an('error');
+      expect(caught.message).to.equal('mentionSentimentGuidance must be at most 4000 characters');
+      expect(caught.status).to.equal(400);
+    });
+
     it('does NOT overwrite an existing brand site_id and warns (LLMO-5556)', async () => {
       const log = { warn: sinon.stub(), info: sinon.stub(), error: sinon.stub() };
       const client = createCapturingClient({

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -167,6 +167,26 @@ describe('Customer Config Mapper', () => {
       expect(result.customer.brands[0].mentionSentimentGuidance).to.equal(null);
     });
 
+    it('strips control/invisible/bidi chars from legacy guidance (parity with the storage path)', () => {
+      // Good{U+202E bidi override}{U+200B zero-width}{NUL}{U+2028 line sep}text 🚀
+      const dirty = `Good${String.fromCharCode(0x202E)}${String.fromCharCode(0x200B)}`
+        + `${String.fromCharCode(0)}${String.fromCharCode(0x2028)}text 🚀`;
+      const llmoConfig = {
+        brands: {
+          aliases: [
+            { name: 'Test Brand', regions: ['US'] },
+          ],
+        },
+        claims: { brandContext: dirty },
+        categories: {},
+        topics: {},
+      };
+
+      const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
+      // Bidi/zero-width/control/line-separator removed; letters, space and emoji preserved.
+      expect(result.customer.brands[0].brandContext).to.equal('Goodtext 🚀');
+    });
+
     it('truncates over-length guidance on code-point boundaries (no split astral chars)', () => {
       const llmoConfig = {
         brands: {

--- a/test/support/customer-config-mapper.test.js
+++ b/test/support/customer-config-mapper.test.js
@@ -167,6 +167,29 @@ describe('Customer Config Mapper', () => {
       expect(result.customer.brands[0].mentionSentimentGuidance).to.equal(null);
     });
 
+    it('truncates over-length guidance on code-point boundaries (no split astral chars)', () => {
+      const llmoConfig = {
+        brands: {
+          aliases: [
+            { name: 'Test Brand', regions: ['US'] },
+          ],
+        },
+        claims: {
+          // 4001 rocket emoji (each 1 code point / 2 UTF-16 units).
+          brandContext: '🚀'.repeat(4001),
+        },
+        categories: {},
+        topics: {},
+      };
+
+      const result = convertV1ToV2(llmoConfig, 'TestCo', 'test@org');
+      const { brandContext } = result.customer.brands[0];
+      // Truncated to 4000 whole code points, not 4000 UTF-16 units mid-emoji.
+      // (A naive slice(0, 4000) would yield 2000 emoji + a lone low surrogate.)
+      expect([...brandContext]).to.have.lengthOf(4000);
+      expect(brandContext).to.equal('🚀'.repeat(4000));
+    });
+
     it('handles null and non-string legacy claims guidance values', () => {
       const llmoConfig = {
         brands: {


### PR DESCRIPTION
## Context

Follow-up to the review question on adobe/project-elmo-ui#3121 — do we sanitize the user input for the Claims-extraction guidance fields? This hardens the server side.

`brandContext` and `mentionSentimentGuidance` are user-submitted free text, persisted verbatim and later interpolated into the Claims-extraction LLM prompt (Mystique).

## Before this PR

- Controller `validateBrandGuidanceFields`: type check + trimmed length ≤ 4000 → 400.
- Storage `normalizeNullableText`: type check, trim, empty→null. **No content sanitization, no length backstop.**
- Config mapper: trim, empty→null, `slice(0, 4000)`.

So raw control / zero-width / bidi-override chars flowed straight into storage and the prompt, and a non-controller caller of the exported `buildBrandRow`/`updateBrand` could persist unbounded text.

## Changes

- **Sanitize at the storage boundary** (`brands-storage.js`) — strip characters with no legitimate meaning in guidance prose that corrupt the prompt, logs/terminals, or a bidi-aware renderer:
  - C0/C1 control chars (except `\t \n \r`), DEL
  - zero-width / word-joiner / BOM (U+200B–200D, U+2060, U+FEFF)
  - line/paragraph separators (U+2028, U+2029)
  - bidirectional override + isolate controls — the "Trojan Source" class (U+202A–202E, U+2066–2069)

  Ordinary whitespace and all printable Unicode (RTL letters, accents, emoji) are preserved. Lone surrogates are **deliberately not** stripped (that range in a non-`u` regex would delete valid astral chars).
- **Length backstop at storage** — enforce the 4000 cap in `normalizeNullableText` (defense-in-depth; `buildBrandRow`/`updateBrand` are reachable without the controller), measured in code points on the sanitized value.
- **Code-point-safe truncation** in the config mapper — `[...str].slice(0, n).join('')` instead of `slice`, so an over-length legacy value can no longer be cut mid-emoji into an invalid lone surrogate.

## Scope / non-goals

Input sanitization here is **defense-in-depth only**. Prompt injection is not solvable at input time and remains owned by the LLM template's data-fencing at prompt-assembly time (Mystique).

Two adjacent items surfaced during review but intentionally **out of scope** here (flagging for follow-up): the sibling `name`/`description`/`vertical` fields share this write path with no sanitization/length cap; and the 4000 limit is defined in three places (controller/mapper/schema) with divergent reject-vs-truncate behavior — worth consolidating onto one shared constant.

## Validation

- `test/support/brands-storage.test.js` — new tests: strips control/bidi/zero-width/line-sep while keeping printable text + emoji; rejects >4000 with a 400.
- `test/support/customer-config-mapper.test.js` — new test: truncates on code-point boundaries (no split astral char).
- Full `brands-storage` + `customer-config-mapper` suites pass (278). ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Defense-in-depth sanitization and length capping of free-text fields; not an auth boundary, reversible by redeploy."
```