### PR TITLE
fix(serenity): stabilize tag re-parent response

### DIFF
--- a/src/support/serenity/handlers/tags.js
+++ b/src/support/serenity/handlers/tags.js
@@ -264,9 +264,9 @@ function parseCreateTagBody(body) {
 /**
  * Picks the created/updated tag's upstream id + parent id out of the transport
  * result. `createProjectTags` resolves to a LIST (model.TreeNodeResponse[]);
- * `updateProjectTag` to a single object. Returns `{ id, parentId }` with
- * `parentId` falling back to the requested `parentId` (so the echo is stable even
- * if the upstream omits it), or null.
+ * `updateProjectTag` to a single object. A validated parent sent to upstream is
+ * authoritative because update responses may intermittently echo the old
+ * `parent_id`; the upstream value is used only when no intended parent is known.
  *
  * @param {any} result - transport result (array for create, object for update).
  * @param {string | null | undefined} requestedParentId
@@ -275,9 +275,12 @@ function parseCreateTagBody(body) {
 function pickTagIds(result, requestedParentId) {
   const node = Array.isArray(result) ? result[0] : result;
   const id = node && typeof node.id === 'string' ? node.id : undefined;
-  const parentId = node && typeof node.parent_id === 'string' && node.parent_id
+  const upstreamParentId = node && typeof node.parent_id === 'string' && node.parent_id
     ? node.parent_id
-    : (requestedParentId ?? null);
+    : null;
+  const parentId = requestedParentId !== undefined
+    ? requestedParentId
+    : upstreamParentId;
   return { id, parentId };
 }
 

--- a/test/support/serenity/handlers/tags.test.js
+++ b/test/support/serenity/handlers/tags.test.js
@@ -1428,6 +1428,36 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       );
     });
 
+    it('returns the requested parent when an explicit re-parent gets a stale upstream echo', async () => {
+      const transport = makeTransport({
+        updateProjectTag: sinon.stub().resolves({
+          id: TAG_IDS.subCategoryHuman,
+          name: 'human',
+          parent_id: TAG_IDS.categoryRunningShoes,
+        }),
+      });
+      const dataAccess = makeDataAccess({ getSemrushProjectId: () => 'proj-1' });
+      const res = await handler.handleUpdateTag(
+        transport,
+        dataAccess,
+        BRAND,
+        WORKSPACE,
+        TAG_IDS.subCategoryHuman,
+        {
+          name: 'human',
+          parentId: TAG_IDS.categoryRoot,
+          geoTargetId: 2840,
+          languageCode: 'en',
+        },
+        fakeLog(),
+      );
+
+      expect(res.body.parentId).to.equal(TAG_IDS.categoryRoot);
+      expect(res.body.path).to.deep.equal([
+        { id: TAG_IDS.categoryRoot, name: 'category' },
+      ]);
+    });
+
     // A server-owned value is a descendant too, so it is renameable through
     // the same path — the dimension root above it is what is protected. The
     // vocabulary is authored by the server. Every resolve-or-create keys on the
@@ -1882,6 +1912,34 @@ describe('serenity tags handler (POST /serenity/tags)', () => {
       expect(res.body).to.not.have.property('brandId');
       expect(transport.updateProjectTag)
         .to.have.been.calledOnceWithExactly(WORKSPACE, 'proj-sub-1', TARGET, { name: 'Footwear', parentId: TAG_IDS.categoryRoot });
+    });
+
+    it('returns the requested parent when an explicit re-parent gets a stale upstream echo', async () => {
+      const handler = await loadHandler(sinon.stub().resolves({ id: 'proj-sub-1' }));
+      const transport = makeTransport({
+        updateProjectTag: sinon.stub().resolves({
+          id: TAG_IDS.subCategoryHuman,
+          name: 'human',
+          parent_id: TAG_IDS.categoryRunningShoes,
+        }),
+      });
+      const res = await handler.handleUpdateTagSubworkspace(
+        transport,
+        WORKSPACE,
+        TAG_IDS.subCategoryHuman,
+        {
+          name: 'human',
+          parentId: TAG_IDS.categoryRoot,
+          geoTargetId: 2840,
+          languageCode: 'en',
+        },
+        fakeLog(),
+      );
+
+      expect(res.body.parentId).to.equal(TAG_IDS.categoryRoot);
+      expect(res.body.path).to.deep.equal([
+        { id: TAG_IDS.categoryRoot, name: 'category' },
+      ]);
     });
 
     // The subworkspace twin shares buildUpdatePayload and the placement guard, so


### PR DESCRIPTION
## Summary

- make the validated parent sent to Project Engine authoritative in tag update responses
- avoid exposing an intermittently stale upstream `parent_id` after a successful re-parent
- preserve rename-only behavior by continuing to send and return the existing validated parent
- add regression coverage for flat and subworkspace handlers

## Production finding

During reversible custom-tag acceptance testing against `Assets Essentials Beta Org 1` / `Brand-A` / `2756-de`, 2 of 3 successful re-parent calls returned the old `parentId`. The persisted tree and returned `path` both reflected the requested new parent.

The handler preferred `parent_id` from the upstream update response, which can intermittently echo the pre-update value. The API has already resolved, validated, and sent the intended parent, so this change uses that value for the public response.

## Validation

- `npx mocha --timeout 10000 --spec=test/support/serenity/handlers/tags.test.js` (111 passing)
- `npx eslint src/support/serenity/handlers/tags.js test/support/serenity/handlers/tags.test.js`
- `npm run type-check`
- `git diff --check`

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Handler fix returns the already-validated parent instead of a stale upstream value; small, reversible by redeploy."
```