### PR TITLE
feat: add metric param to Serenity sentiment-overview | LLMO-7457

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12931,7 +12931,7 @@ SerenityBrandPresenceSentimentOverview:
     verbatim so the existing chart consumes it drop-in — the absolute values
     differ from the Postgres-backed legacy endpoint (Semrush metrics), but the
     shape, `sentiment[]` ordering, and colors are identical.
-  required: [weeklyTrends]
+  required: [metric, weeklyTrends]
   properties:
     metric:
       type: string
@@ -12949,6 +12949,9 @@ SerenityBrandPresenceSentimentOverview:
           - weekNumber
           - year
           - sentiment
+          - mentionCounts
+          - promptCounts
+          - sentimentTotal
           - totalPrompts
           - promptsWithSentiment
         properties:
@@ -12985,6 +12988,7 @@ SerenityBrandPresenceSentimentOverview:
               Raw per-sentiment MENTION counts for the week (the element's
               `value`). Returned regardless of `metric`, so a caller can render
               true counts alongside the percentages as the Semrush MFE does.
+            required: [positive, neutral, negative]
             properties:
               positive: { type: integer, example: 443 }
               neutral: { type: integer, example: 571 }
@@ -12994,6 +12998,7 @@ SerenityBrandPresenceSentimentOverview:
             description: |
               Raw per-sentiment PROMPT counts for the week (the element's
               `value__prompts`). Returned regardless of `metric`.
+            required: [positive, neutral, negative]
             properties:
               positive: { type: integer, example: 165 }
               neutral: { type: integer, example: 208 }

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12939,6 +12939,12 @@ SerenityBrandPresenceSentimentOverview:
       description: |
         The resolved `metric` the `sentiment[]` percentages were computed over —
         echoed back so a caller can confirm which definition it received.
+
+        Temporary (LLMO-7457). The `metric` REQUEST parameter is removed once the
+        UI has migrated to `mentions`, but this response field is not simply
+        dropped: at that point the enum must NARROW to `[mentions]`, so a client
+        that switches on it keeps working. `mentionCounts` and `sentimentTotal`
+        are permanent; `promptCounts` goes with the `prompts` branch.
     weeklyTrends:
       type: array
       description: One entry per ISO week in the requested range, ordered oldest-first.
@@ -12998,6 +13004,9 @@ SerenityBrandPresenceSentimentOverview:
             description: |
               Raw per-sentiment PROMPT counts for the week (the element's
               `value__prompts`). Returned regardless of `metric`.
+
+              Temporary (LLMO-7457): removed alongside the `prompts` branch once
+              the UI has migrated to `mentions`.
             required: [positive, neutral, negative]
             properties:
               positive: { type: integer, example: 165 }
@@ -13025,7 +13034,11 @@ SerenityBrandPresenceSentimentOverview:
               sum-of-three.
           mentions:
             type: integer
-            description: Stubbed 0 (parity with the legacy contract).
+            description: |
+              Stubbed 0 (parity with the legacy contract). This is NOT a mention
+              count — it has always been a hardcoded 0 on this endpoint. For real
+              per-sentiment mention data, read `mentionCounts` above; a 0 here
+              does not mean the brand has no mentions.
           citations:
             type: integer
             description: Stubbed 0 (parity with the legacy contract).

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -12933,6 +12933,12 @@ SerenityBrandPresenceSentimentOverview:
     shape, `sentiment[]` ordering, and colors are identical.
   required: [weeklyTrends]
   properties:
+    metric:
+      type: string
+      enum: [prompts, mentions]
+      description: |
+        The resolved `metric` the `sentiment[]` percentages were computed over —
+        echoed back so a caller can confirm which definition it received.
     weeklyTrends:
       type: array
       description: One entry per ISO week in the requested range, ordered oldest-first.
@@ -12966,10 +12972,38 @@ SerenityBrandPresenceSentimentOverview:
                   enum: [Positive, Neutral, Negative]
                 value:
                   type: integer
-                  description: Percentage of prompts-with-sentiment in this bucket (0-100).
+                  description: |
+                    Percentage of the selected `metric`'s total in this bucket
+                    (0-100). The denominator is the sum of the three buckets
+                    (`sentimentTotal`), matching how the Semrush MFE normalises.
                 color:
                   type: string
                   description: Legacy sentiment swatch hex.
+          mentionCounts:
+            type: object
+            description: |
+              Raw per-sentiment MENTION counts for the week (the element's
+              `value`). Returned regardless of `metric`, so a caller can render
+              true counts alongside the percentages as the Semrush MFE does.
+            properties:
+              positive: { type: integer, example: 443 }
+              neutral: { type: integer, example: 571 }
+              negative: { type: integer, example: 7 }
+          promptCounts:
+            type: object
+            description: |
+              Raw per-sentiment PROMPT counts for the week (the element's
+              `value__prompts`). Returned regardless of `metric`.
+            properties:
+              positive: { type: integer, example: 165 }
+              neutral: { type: integer, example: 208 }
+              negative: { type: integer, example: 7 }
+          sentimentTotal:
+            type: integer
+            description: |
+              The denominator used for `sentiment[]` — the sum of the three
+              buckets of whichever count set `metric` selected.
+            example: 1021
           totalPrompts:
             type: integer
             description: |
@@ -12977,10 +13011,13 @@ SerenityBrandPresenceSentimentOverview:
           promptsWithSentiment:
             type: integer
             description: |
-              Positive + Neutral + Negative prompt counts. NOTE: the three
-              sentiment buckets are overlapping sets (a prompt with mixed-sentiment
-              mentions counts in each), so this can exceed `totalPrompts`; do not
-              derive a coverage ratio from the two.
+              Positive + Neutral + Negative PROMPT counts. Always prompt-based,
+              whatever `metric` is set to, so this field never changes meaning.
+              NOTE: the three sentiment buckets are overlapping sets (a prompt
+              with mixed-sentiment mentions counts in each), so this can exceed
+              `totalPrompts`; do not derive a coverage ratio from the two. This
+              overlap is not a defect — the Semrush MFE normalises over the same
+              sum-of-three.
           mentions:
             type: integer
             description: Stubbed 0 (parity with the legacy contract).

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1729,7 +1729,9 @@ v2-serenity-brand-presence-sentiment-overview:
           Unrecognised, blank and absent values all resolve to `prompts` rather
           than returning 400, so an unknown value degrades to today's numbers
           instead of failing the chart request. Aliases: `sentimentMetric`,
-          `sentiment_metric`.
+          `sentiment_metric` — resolution takes the first of the three that is a
+          non-blank string, so a present-but-empty `metric` does not shadow a
+          populated alias.
 
           `mentionCounts` and `promptCounts` are returned regardless of this
           value, so both definitions can be compared from a single call.
@@ -1740,6 +1742,20 @@ v2-serenity-brand-presence-sentiment-overview:
           type: string
           enum: [prompts, mentions]
           default: prompts
+      - name: sentimentMetric
+        in: query
+        required: false
+        description: Alias for `metric`. Used only if `metric` is absent or blank.
+        schema:
+          type: string
+          enum: [prompts, mentions]
+      - name: sentiment_metric
+        in: query
+        required: false
+        description: Snake_case alias for `metric`. Used only if `metric` and `sentimentMetric` are absent or blank.
+        schema:
+          type: string
+          enum: [prompts, mentions]
     responses:
       '200':
         description: Weekly sentiment retrieved.

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1716,6 +1716,30 @@ v2-serenity-brand-presence-sentiment-overview:
           and the bare `category` slug are recognized for the tag prefix
           itself (tag-display-names.md §1 item 6).
         schema: { type: string }
+      - name: metric
+        in: query
+        required: false
+        description: |
+          Which per-legend count drives the `sentiment[]` percentages.
+          `prompts` (default) uses the element's per-prompt counts — this
+          endpoint's original behaviour. `mentions` uses the per-mention counts,
+          which is what the Semrush Brand Presence MFE plots, and reproduces its
+          percentages exactly.
+
+          Unrecognised, blank and absent values all resolve to `prompts` rather
+          than returning 400, so an unknown value degrades to today's numbers
+          instead of failing the chart request. Aliases: `sentimentMetric`,
+          `sentiment_metric`.
+
+          `mentionCounts` and `promptCounts` are returned regardless of this
+          value, so both definitions can be compared from a single call.
+
+          Temporary (LLMO-7457): the default flips to `mentions` and this
+          parameter is removed once the UI has migrated.
+        schema:
+          type: string
+          enum: [prompts, mentions]
+          default: prompts
     responses:
       '200':
         description: Weekly sentiment retrieved.

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -23,6 +23,7 @@ import { createElementsService } from '../support/elements/elements-service.js';
 import { fetchOwnedUrlsTraffic, mergeOwnedUrlsTraffic } from '../support/elements/owned-urls-traffic.js';
 import { mapWithConcurrency } from '../support/elements/concurrency.js';
 import { addDaysToDate } from '../support/elements/week-utils.js';
+import { SENTIMENT_METRICS } from '../support/elements/definitions/sentiment-overview.js';
 import { resolveBrandWorkspace } from '../support/serenity/workspace-resolver.js';
 import { isSerenityActiveForBrand } from '../support/serenity/serenity-active.js';
 import { createSerenityTransport } from '../support/serenity/rest-transport.js';
@@ -343,6 +344,28 @@ function extractProjectIds(query) {
     );
   }
   return ids;
+}
+
+/**
+ * Normalises the `metric`/`sentiment_metric` query param for the sentiment-overview
+ * endpoint (LLMO-7457), mirroring the shape of {@link parseShowTrends}.
+ *
+ * Only the exact opt-in `'mentions'` (case-insensitive, trimmed) selects mention counts.
+ * Anything else — absent, blank, or unrecognised — resolves to `'prompts'`, this
+ * endpoint's original behaviour. Deliberately permissive rather than a 400: an
+ * unrecognised value degrades to today's numbers instead of failing a chart request.
+ *
+ * Exported for direct unit testing, for the same reason as {@link parseShowTrends}.
+ *
+ * @param {object} q - Query object from `extractQuery`.
+ * @returns {'prompts'|'mentions'}
+ */
+export function parseSentimentMetric(q) {
+  const v = q?.metric ?? q?.sentimentMetric ?? q?.sentiment_metric;
+  if (typeof v === 'string' && v.trim().toLowerCase() === SENTIMENT_METRICS.MENTIONS) {
+    return SENTIMENT_METRICS.MENTIONS;
+  }
+  return SENTIMENT_METRICS.PROMPTS;
 }
 
 /**
@@ -1235,6 +1258,13 @@ export default function ElementsController(context, log, env) {
    * the brand's display name: without the latter the element blends in every competitor
    * tracked in the same sub-workspace, since that is also where Market Comparison's rivals
    * live (LLMO-7456 — see sentiment-overview.js for the live A/B).
+   *
+   * `metric` (optional, `prompts` | `mentions`) selects which per-legend count drives the
+   * percentages. Defaults to `prompts`, this endpoint's original behaviour; `mentions`
+   * matches what the Semrush Brand Presence MFE plots (LLMO-7457). Both count sets are
+   * returned regardless, as `mentionCounts` / `promptCounts`, so a caller can render true
+   * counts alongside the percentages and compare both definitions from one call.
+   * Temporary: the default flips to `mentions` and this param is removed once the UI moves.
    */
   /* c8 ignore start -- LLMO-6300 POC endpoint; unit tests intentionally deferred */
   const listSentimentOverview = async (ctx) => {
@@ -1288,6 +1318,7 @@ export default function ElementsController(context, log, env) {
         endDate,
         category: query.categoryId || query.category,
         brandName: resolveBrandFilterName(brand, log, 'listSentimentOverview'),
+        metric: parseSentimentMetric(query),
         ...tagFilterParams(query),
       };
 

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -23,7 +23,7 @@ import { createElementsService } from '../support/elements/elements-service.js';
 import { fetchOwnedUrlsTraffic, mergeOwnedUrlsTraffic } from '../support/elements/owned-urls-traffic.js';
 import { mapWithConcurrency } from '../support/elements/concurrency.js';
 import { addDaysToDate } from '../support/elements/week-utils.js';
-import { SENTIMENT_METRICS } from '../support/elements/definitions/sentiment-overview.js';
+import { normalizeSentimentMetric, SENTIMENT_METRICS } from '../support/elements/definitions/index.js';
 import { resolveBrandWorkspace } from '../support/serenity/workspace-resolver.js';
 import { isSerenityActiveForBrand } from '../support/serenity/serenity-active.js';
 import { createSerenityTransport } from '../support/serenity/rest-transport.js';
@@ -347,13 +347,19 @@ function extractProjectIds(query) {
 }
 
 /**
- * Normalises the `metric`/`sentiment_metric` query param for the sentiment-overview
- * endpoint (LLMO-7457), mirroring the shape of {@link parseShowTrends}.
+ * Normalises the `metric`/`sentimentMetric`/`sentiment_metric` query param for the
+ * sentiment-overview endpoint (LLMO-7457), mirroring the shape of {@link parseShowTrends}.
  *
- * Only the exact opt-in `'mentions'` (case-insensitive, trimmed) selects mention counts.
- * Anything else — absent, blank, or unrecognised — resolves to `'prompts'`, this
- * endpoint's original behaviour. Deliberately permissive rather than a 400: an
- * unrecognised value degrades to today's numbers instead of failing a chart request.
+ * Resolution walks the three accepted names and takes the first that is a NON-BLANK
+ * string, so a present-but-empty `metric` does not shadow a populated alias. `??` alone
+ * would have: it only skips null/undefined, so `{ metric: '', sentiment_metric: 'mentions' }`
+ * would have resolved to `prompts`.
+ *
+ * The value itself is normalised by `normalizeSentimentMetric`, shared with the
+ * transform, so both layers agree on what counts as the opt-in. Only the exact
+ * `'mentions'` (trimmed, case-insensitive) selects mention counts; anything else
+ * degrades to `'prompts'` rather than 400, so an unrecognised value returns today's
+ * numbers instead of failing an otherwise-valid chart request.
  *
  * Exported for direct unit testing, for the same reason as {@link parseShowTrends}.
  *
@@ -361,11 +367,9 @@ function extractProjectIds(query) {
  * @returns {'prompts'|'mentions'}
  */
 export function parseSentimentMetric(q) {
-  const v = q?.metric ?? q?.sentimentMetric ?? q?.sentiment_metric;
-  if (typeof v === 'string' && v.trim().toLowerCase() === SENTIMENT_METRICS.MENTIONS) {
-    return SENTIMENT_METRICS.MENTIONS;
-  }
-  return SENTIMENT_METRICS.PROMPTS;
+  const candidates = [q?.metric, q?.sentimentMetric, q?.sentiment_metric];
+  const supplied = candidates.find((v) => typeof v === 'string' && v.trim() !== '');
+  return normalizeSentimentMetric(supplied);
 }
 
 /**
@@ -1323,6 +1327,27 @@ export default function ElementsController(context, log, env) {
       };
 
       const result = await service.getSentimentOverview(workspaceId, params);
+      // The metric parse is deliberately permissive and this handler is
+      // coverage-ignored, so a mis-spelled param produces no error and no test
+      // failure. Log the non-default opt-in so the production A/B this parameter
+      // exists for is traceable from the server side, not only from the echoed
+      // field in a response someone happens to inspect (LLMO-7457).
+      if (params.metric !== SENTIMENT_METRICS.PROMPTS) {
+        log.info(`[serenity] sentiment-overview metric=${params.metric} brandId=${brand?.id}`);
+      }
+      // A zero basis while the other count set is non-empty means the upstream
+      // field this metric reads has gone missing, which otherwise surfaces only
+      // as an unexplained empty chart.
+      const suspectWeek = (result?.weeklyTrends ?? []).find((w) => {
+        const isMentions = params.metric === SENTIMENT_METRICS.MENTIONS;
+        const basis = isMentions ? w.mentionCounts : w.promptCounts;
+        const other = isMentions ? w.promptCounts : w.mentionCounts;
+        const sum = (c) => (c ? c.positive + c.neutral + c.negative : 0);
+        return sum(basis) === 0 && sum(other) > 0;
+      });
+      if (suspectWeek) {
+        log.warn(`[serenity] sentiment-overview metric=${params.metric} has a zero basis while the other count set is non-empty - week=${suspectWeek.week} brandId=${brand?.id}`);
+      }
       return cachedOk(result);
     } catch (e) {
       return mapError(e, log, reqCtxOf(ctx));

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -52,6 +52,7 @@ export { aggregateTopicsFromPrompts } from './topics-insights.js';
 export {
   buildSentimentOverviewPayload,
   transformSentimentOverviewResponse,
+  normalizeSentimentMetric,
   SENTIMENT_METRICS,
 } from './sentiment-overview.js';
 export {

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -52,6 +52,7 @@ export { aggregateTopicsFromPrompts } from './topics-insights.js';
 export {
   buildSentimentOverviewPayload,
   transformSentimentOverviewResponse,
+  SENTIMENT_METRICS,
 } from './sentiment-overview.js';
 export {
   buildOwnedUrlsStatsPayload,

--- a/src/support/elements/definitions/sentiment-overview.js
+++ b/src/support/elements/definitions/sentiment-overview.js
@@ -167,6 +167,22 @@ function parseIsoWeekParts(weekStr) {
 
 const SENTIMENT_BUCKETS = ['positive', 'neutral', 'negative'];
 
+/**
+ * Which per-legend count drives the sentiment percentages (LLMO-7457).
+ *
+ * `PROMPTS` is the default and preserves this endpoint's original behaviour.
+ * `MENTIONS` matches the Semrush Brand Presence MFE — see the verification note on
+ * {@link transformSentimentOverviewResponse}.
+ *
+ * Temporary: this exists so both definitions can be compared in production (no dev org is
+ * correctly wired to Semrush). Once the UI has moved to `mentions`, the default flips and
+ * the `prompts` branch is removed along with this map.
+ */
+export const SENTIMENT_METRICS = Object.freeze({
+  PROMPTS: 'prompts',
+  MENTIONS: 'mentions',
+});
+
 // Guard against a non-date `bar` value (e.g. a metadata / "N/A" row from the upstream
 // element): an invalid day slices to junk that dateToIsoWeek turns into a "NaN-WNaN"
 // key, which would surface as a phantom weeklyTrends entry (weekNumber/year 0). Only a
@@ -180,8 +196,9 @@ function isoDayOf(bar) {
 /**
  * Transforms the raw Sentiment element response into the legacy Brand Presence
  * `sentiment-overview` contract so the sentiment chart is drop-in compatible:
- *   { weeklyTrends: [{ week, weekNumber, year,
+ *   { metric, weeklyTrends: [{ week, weekNumber, year,
  *       sentiment: [{ name, value, color } x Positive/Neutral/Negative],
+ *       mentionCounts, promptCounts, sentimentTotal,
  *       totalPrompts, promptsWithSentiment, mentions, citations,
  *       visibilityScore, competitors }] }
  * ordered oldest-first (matches the legacy aggregateSentimentByWeek sort).
@@ -198,9 +215,24 @@ function isoDayOf(bar) {
  * below is granularity-agnostic: one row per week means the per-week sums are identities, and
  * it would still correctly roll up were the element ever queried at daily granularity.)
  * Field mapping:
- *   positive/neutral/negative prompt counts ← `value__prompts` per legend for the week
- *   totalPrompts                            ← `blocks.line[].value` for the week
+ *   mentionCounts (positive/neutral/negative) ← `value` per legend for the week
+ *   promptCounts  (positive/neutral/negative) ← `value__prompts` per legend for the week
+ *   totalPrompts                              ← `blocks.line[].value` for the week
  *   mentions/citations/visibilityScore/competitors — stubbed 0/[] (as in the legacy handler)
+ *
+ * WHICH COUNT DRIVES THE PERCENTAGES — the `metric` param (LLMO-7457):
+ *   - `'prompts'`  (DEFAULT) → `value__prompts`. The behaviour this endpoint has always had.
+ *   - `'mentions'`           → `value`. What the Semrush Brand Presence MFE plots.
+ * VERIFIED against a live MFE tooltip (brand "au", bucket 2026-08-21): it showed
+ * Negative 1% / 7, Neutral 56% / 571, Positive 43% / 443. The raw row's `value` is
+ * 7/571/443 (exact match) while `value__prompts` is 7/208/165 (no match) — so the MFE
+ * plots `value`. Its percentages are each value over the SUM OF THE THREE (1021 → 1/56/43,
+ * an exact match); the `blocks.line` distinct total (275) yields 3/208/161 and is therefore
+ * definitively NOT the MFE's denominator. Our long-standing rounding rule below, applied to
+ * mentions, reproduces the MFE output exactly.
+ * BOTH count sets are returned on every response regardless of `metric`, so a caller can
+ * render true counts alongside the percentages (as the MFE does) and compare the two
+ * definitions from a single call.
  *
  * SEMANTIC NOTE: the three legends are OVERLAPPING sets, not a partition — a prompt with
  * mixed-sentiment mentions is counted in every legend it appears in. So Σ(value__prompts
@@ -210,24 +242,35 @@ function isoDayOf(bar) {
  *     invariant in aggregateSentimentByWeek where the three counts sum to it), so it
  *     can exceed `totalPrompts`. Do NOT compute promptsWithSentiment/totalPrompts as a
  *     coverage ratio in the UI — it can exceed 100%. (Flag for the UI-wiring follow-up.)
+ *   - This overlap is NOT a defect to correct: the MFE normalises over the same
+ *     sum-of-three (see the verification above). Do not "fix" it to the distinct total.
  *   - The sentiment PERCENTAGES are internal ratios of the three legend counts and are
  *     unaffected by this overlap; they are the chart's load-bearing content.
  * Percentages are computed exactly as the legacy handler: round positive & negative,
  * neutral = 100 − positive − negative (so the three always sum to 100).
  *
  * @param {object} raw - Raw response from the Sentiment element.
- * @returns {{ weeklyTrends: Array<object> }}
+ * @param {object} [options]
+ * @param {'prompts'|'mentions'} [options.metric] - Which count drives the percentages.
+ *   Anything other than `'mentions'` (including absent) means `'prompts'`; the controller
+ *   normalises the query value via {@link parseSentimentMetric} before this is reached.
+ * @returns {{ metric: string, weeklyTrends: Array<object> }}
  */
-export function transformSentimentOverviewResponse(raw) {
+export function transformSentimentOverviewResponse(raw, { metric } = {}) {
+  // Only the explicit 'mentions' opt-in switches the source field; every other value
+  // (absent, blank, unrecognised) keeps today's prompt-based behaviour.
+  const useMentions = metric === SENTIMENT_METRICS.MENTIONS;
   const rows = Array.isArray(raw?.blocks?.data) ? raw.blocks.data : [];
   const lineRows = Array.isArray(raw?.blocks?.line) ? raw.blocks.line : [];
 
-  // week -> { positive, neutral, negative, totalPrompts }
+  // week -> per-legend mention + prompt counts, plus the distinct-response line total.
   const weekMap = new Map();
   const ensureWeek = (week) => {
     if (!weekMap.has(week)) {
       weekMap.set(week, {
-        positive: 0, neutral: 0, negative: 0, totalPrompts: 0,
+        mentions: { positive: 0, neutral: 0, negative: 0 },
+        prompts: { positive: 0, neutral: 0, negative: 0 },
+        totalPrompts: 0,
       });
     }
     return weekMap.get(week);
@@ -239,9 +282,12 @@ export function transformSentimentOverviewResponse(raw) {
     if (!day || !SENTIMENT_BUCKETS.includes(bucket)) {
       return;
     }
-    const week = dateToIsoWeek(day);
+    const entry = ensureWeek(dateToIsoWeek(day));
     // `Number(x) || 0` (not `?? 0`) so a non-numeric value coerces to 0, not NaN.
-    ensureWeek(week)[bucket] += Number(row.value__prompts) || 0;
+    // Both counts are accumulated on every row so the response can carry both sets
+    // regardless of which one `metric` selects for the percentages.
+    entry.mentions[bucket] += Number(row.value) || 0;
+    entry.prompts[bucket] += Number(row.value__prompts) || 0;
   });
 
   // The total-prompts line is a separate per-day series; fold it into the same weeks.
@@ -257,13 +303,20 @@ export function transformSentimentOverviewResponse(raw) {
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([week, entry]) => {
       const { weekNumber, year } = parseIsoWeekParts(week);
-      const promptsWithSentiment = entry.positive + entry.neutral + entry.negative;
+      const { mentions: mentionCounts, prompts: promptCounts } = entry;
+      // The selected metric drives the percentages; the other set still ships.
+      const basis = useMentions ? mentionCounts : promptCounts;
+      const basisTotal = basis.positive + basis.neutral + basis.negative;
+      // Unchanged meaning: always the sum of the three PROMPT counts, whatever `metric` is,
+      // so this field does not silently change definition for existing consumers.
+      const promptsWithSentiment = promptCounts.positive
+        + promptCounts.neutral + promptCounts.negative;
       let positivePct = 0;
       let negativePct = 0;
       let neutralPct = 0;
-      if (promptsWithSentiment > 0) {
-        positivePct = Math.round((entry.positive / promptsWithSentiment) * 100);
-        negativePct = Math.round((entry.negative / promptsWithSentiment) * 100);
+      if (basisTotal > 0) {
+        positivePct = Math.round((basis.positive / basisTotal) * 100);
+        negativePct = Math.round((basis.negative / basisTotal) * 100);
         neutralPct = 100 - positivePct - negativePct;
         // Independent rounding of positive & negative can push their sum to 101
         // (e.g. 50.5→51 and 49.5→50), making the neutral remainder negative. Absorb
@@ -288,6 +341,11 @@ export function transformSentimentOverviewResponse(raw) {
           { name: 'Neutral', value: neutralPct, color: SENTIMENT_COLORS.neutral },
           { name: 'Negative', value: negativePct, color: SENTIMENT_COLORS.negative },
         ],
+        // Raw counts for both definitions — additive, so existing consumers are unaffected.
+        mentionCounts,
+        promptCounts,
+        // The denominator the percentages above were computed over.
+        sentimentTotal: basisTotal,
         totalPrompts: entry.totalPrompts,
         promptsWithSentiment,
         mentions: 0,
@@ -297,7 +355,10 @@ export function transformSentimentOverviewResponse(raw) {
       };
     });
 
-  return { weeklyTrends };
+  return {
+    metric: useMentions ? SENTIMENT_METRICS.MENTIONS : SENTIMENT_METRICS.PROMPTS,
+    weeklyTrends,
+  };
 }
 
 export { SENTIMENT_COLORS };

--- a/src/support/elements/definitions/sentiment-overview.js
+++ b/src/support/elements/definitions/sentiment-overview.js
@@ -183,6 +183,28 @@ export const SENTIMENT_METRICS = Object.freeze({
   MENTIONS: 'mentions',
 });
 
+/**
+ * Normalises one candidate metric value to a {@link SENTIMENT_METRICS} member.
+ *
+ * Trims and lowercases, so `' MENTIONS '` resolves like `'mentions'`. Only that
+ * one opt-in selects mention counts; everything else — absent, blank,
+ * unrecognised, non-string — resolves to `PROMPTS`, this endpoint's original
+ * behaviour. Deliberately permissive rather than throwing: an unrecognised value
+ * should degrade to today's numbers, not fail an otherwise-valid chart request.
+ *
+ * Shared by the controller's query-param parsing and by
+ * {@link transformSentimentOverviewResponse}, so a direct service caller gets the
+ * same answer as an HTTP one rather than silently falling back on casing alone.
+ *
+ * @param {*} value - Raw candidate value.
+ * @returns {'prompts'|'mentions'}
+ */
+export function normalizeSentimentMetric(value) {
+  return (typeof value === 'string' && value.trim().toLowerCase() === SENTIMENT_METRICS.MENTIONS)
+    ? SENTIMENT_METRICS.MENTIONS
+    : SENTIMENT_METRICS.PROMPTS;
+}
+
 // Guard against a non-date `bar` value (e.g. a metadata / "N/A" row from the upstream
 // element): an invalid day slices to junk that dateToIsoWeek turns into a "NaN-WNaN"
 // key, which would surface as a phantom weeklyTrends entry (weekNumber/year 0). Only a
@@ -252,14 +274,16 @@ function isoDayOf(bar) {
  * @param {object} raw - Raw response from the Sentiment element.
  * @param {object} [options]
  * @param {'prompts'|'mentions'} [options.metric] - Which count drives the percentages.
- *   Anything other than `'mentions'` (including absent) means `'prompts'`; the controller
- *   normalises the query value via {@link parseSentimentMetric} before this is reached.
+ *   Normalised via `normalizeSentimentMetric`, so a trimmed/cased value from a direct
+ *   service caller resolves the same way an HTTP query value does. Anything other than
+ *   `'mentions'` (including absent) means `'prompts'`.
  * @returns {{ metric: string, weeklyTrends: Array<object> }}
  */
 export function transformSentimentOverviewResponse(raw, { metric } = {}) {
-  // Only the explicit 'mentions' opt-in switches the source field; every other value
-  // (absent, blank, unrecognised) keeps today's prompt-based behaviour.
-  const useMentions = metric === SENTIMENT_METRICS.MENTIONS;
+  // Shared with the controller's query parsing so both layers agree; only the
+  // explicit 'mentions' opt-in switches the source field.
+  const resolvedMetric = normalizeSentimentMetric(metric);
+  const useMentions = resolvedMetric === SENTIMENT_METRICS.MENTIONS;
   const rows = Array.isArray(raw?.blocks?.data) ? raw.blocks.data : [];
   const lineRows = Array.isArray(raw?.blocks?.line) ? raw.blocks.line : [];
 
@@ -356,7 +380,7 @@ export function transformSentimentOverviewResponse(raw, { metric } = {}) {
     });
 
   return {
-    metric: useMentions ? SENTIMENT_METRICS.MENTIONS : SENTIMENT_METRICS.PROMPTS,
+    metric: resolvedMetric,
     weeklyTrends,
   };
 }

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -615,8 +615,12 @@ export function createElementsService(transport, log) {
      *
      * @param {string} workspaceId - Semrush workspace UUID.
      * @param {object} params - Query params (model/platform, startDate, endDate, category,
-     *   projectId, projectIds, brandName).
-     * @returns {Promise<{ weeklyTrends: object[] }>} Legacy contract.
+     *   projectId, projectIds, brandName, metric).
+     * @param {'prompts'|'mentions'} [params.metric] - Which per-legend count drives the
+     *   sentiment percentages. Defaults to `prompts` (the original behaviour); `mentions`
+     *   matches the Semrush MFE. Does NOT affect the request payload — the element returns
+     *   both counts on every row, so this only selects which one the transform reads.
+     * @returns {Promise<{ metric: string, weeklyTrends: object[] }>} Legacy contract.
      */
     async getSentimentOverview(workspaceId, params) {
       const raw = await transport.fetchElement(
@@ -624,7 +628,7 @@ export function createElementsService(transport, log) {
         ELEMENT_IDS.SENTIMENT,
         buildSentimentOverviewPayload(params),
       );
-      return transformSentimentOverviewResponse(raw);
+      return transformSentimentOverviewResponse(raw, { metric: params?.metric });
     },
 
     /**

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -16,7 +16,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
 import { ErrorWithStatusCode } from '../../src/support/utils.js';
-import { parseShowTrends, parseUserIntent } from '../../src/controllers/elements.js';
+import { parseShowTrends, parseUserIntent, parseSentimentMetric } from '../../src/controllers/elements.js';
 import { addDaysToDate } from '../../src/support/elements/week-utils.js';
 // Real error class (not a mock) so the controller's `instanceof SerenityTransportError`
 // check in checkAccess matches errors thrown by these tests — and so this file keeps a
@@ -2504,6 +2504,28 @@ describe('ElementsController', () => {
   // Exercised directly (not just through getStats) because extractQuery only
   // ever yields strings from URLSearchParams, so the boolean/number branch
   // below is unreachable via the HTTP query-string path.
+
+  describe('parseSentimentMetric', () => {
+    it("returns 'mentions' only for the explicit opt-in, case-insensitive and trimmed", () => {
+      expect(parseSentimentMetric({ metric: 'mentions' })).to.equal('mentions');
+      expect(parseSentimentMetric({ metric: 'MENTIONS' })).to.equal('mentions');
+      expect(parseSentimentMetric({ metric: '  Mentions  ' })).to.equal('mentions');
+    });
+
+    it('accepts the sentimentMetric / sentiment_metric aliases', () => {
+      expect(parseSentimentMetric({ sentimentMetric: 'mentions' })).to.equal('mentions');
+      expect(parseSentimentMetric({ sentiment_metric: 'mentions' })).to.equal('mentions');
+    });
+
+    // Deliberately permissive: an unrecognised value degrades to today's numbers
+    // rather than failing an otherwise-valid chart request.
+    it("defaults to 'prompts' for absent, blank, unrecognised or non-string values", () => {
+      for (const q of [undefined, null, {}, { metric: '' }, { metric: '  ' },
+        { metric: 'prompts' }, { metric: 'bogus' }, { metric: 42 }, { metric: true }]) {
+        expect(parseSentimentMetric(q), JSON.stringify(q ?? null)).to.equal('prompts');
+      }
+    });
+  });
 
   describe('parseShowTrends', () => {
     it('returns true for the boolean true', () => {

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -529,6 +529,7 @@ const FIXTURES = {
     // service is called (see listSentimentOverview) — supply them via query.
     query: { startDate: '2026-06-01', endDate: '2026-07-16' },
     handlerResult: {
+      metric: 'prompts',
       weeklyTrends: [{
         week: '2026-W24',
         weekNumber: 24,
@@ -538,6 +539,9 @@ const FIXTURES = {
           { name: 'Neutral', value: 39, color: '#4B5563' },
           { name: 'Negative', value: 8, color: '#B91C1C' },
         ],
+        mentionCounts: { positive: 12043, neutral: 8871, negative: 1819 },
+        promptCounts: { positive: 4866, neutral: 3581, negative: 734 },
+        sentimentTotal: 9181,
         totalPrompts: 5261,
         promptsWithSentiment: 9181,
         mentions: 0,

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -527,7 +527,14 @@ const FIXTURES = {
     serviceMethod: 'getSentimentOverview',
     // startDate/endDate are required + validated by the controller before the
     // service is called (see listSentimentOverview) — supply them via query.
-    query: { startDate: '2026-06-01', endDate: '2026-07-16' },
+    query: { startDate: '2026-06-01', endDate: '2026-07-16', metric: 'mentions' },
+    // Pins the controller->service half of the `metric` seam (LLMO-7457). The
+    // service->transform half is covered in elements-service.test.js, but nothing
+    // otherwise asserts the controller WRITES the key it reads: `metric:` at
+    // elements.js:1321 is inside a `c8 ignore` block, so renaming it or dropping
+    // the line would leave `?metric=mentions` a permanent silent no-op with green
+    // CI — the failure this PR's production A/B depends on not having.
+    expectServiceParams: { metric: 'mentions' },
     handlerResult: {
       metric: 'prompts',
       weeklyTrends: [{
@@ -875,6 +882,12 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
       expect(op, `operation ${operationId} not found in spec`).to.exist;
 
       if (fx.usesElementsController) {
+        // Hoisted so a fixture can assert on what the controller actually handed
+        // the service. The controller->service param seam is otherwise untested:
+        // handlers like listSentimentOverview sit inside `c8 ignore` blocks, so a
+        // renamed key (e.g. `sentimentMetric:` instead of `metric:`) would ship
+        // green as a silent no-op. See `expectServiceParams` below.
+        const serviceMethodStub = sinon.stub().resolves(fx.handlerResult);
         const ElementsController = (await esmock(
           '../../src/controllers/elements.js',
           {
@@ -905,7 +918,7 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
             },
             '../../src/support/elements/elements-service.js': {
               createElementsService: () => ({
-                [fx.serviceMethod]: sinon.stub().resolves(fx.handlerResult),
+                [fx.serviceMethod]: serviceMethodStub,
                 resolveRegionProjectId: sinon.stub().resolves(null),
                 // Only consumed by getUrlInspectorStats's aggregate (no-region)
                 // path — without at least one project, it 404s before ever
@@ -936,6 +949,18 @@ describe('OpenAPI contract — /serenity/* endpoints', function specSuite() {
         const response = await controller[fx.controllerMethod](ctx);
 
         expect(response.status).to.equal(fx.expectedStatus);
+
+        // Optional per-fixture assertion on the params the controller built and
+        // passed to the service — the only place that seam is exercised, since
+        // the handlers themselves are coverage-ignored.
+        if (fx.expectServiceParams) {
+          expect(serviceMethodStub, `${operationId}: service was not called`).to.have.been.called;
+          const [, actualParams] = serviceMethodStub.firstCall.args;
+          Object.entries(fx.expectServiceParams).forEach(([key, value]) => {
+            expect(actualParams, `${operationId}: params.${key}`)
+              .to.have.property(key, value);
+          });
+        }
 
         const responseSchema = op.responseSchema(fx.expectedStatus);
         expect(responseSchema, `no ${fx.expectedStatus} schema for ${operationId}`).to.exist;

--- a/test/support/elements/definitions/sentiment-overview.test.js
+++ b/test/support/elements/definitions/sentiment-overview.test.js
@@ -16,6 +16,15 @@ import {
   transformSentimentOverviewResponse,
   SENTIMENT_COLORS,
 } from '../../../../src/support/elements/definitions/sentiment-overview.js';
+import {
+  RAW_SENTIMENT_WEEK,
+  SENTIMENT_MENTIONS_TOTAL,
+  SENTIMENT_PROMPTS_TOTAL,
+  SENTIMENT_MENTIONS_PCT,
+  SENTIMENT_PROMPTS_PCT,
+  SENTIMENT_MENTION_COUNTS,
+  SENTIMENT_PROMPT_COUNTS,
+} from '../fixtures/sentiment-overview.js';
 
 // Locates the CBF_project value inside the advanced filter tree (it sits in its own
 // `or` block, like the CBF_model block), or returns undefined if absent (including when
@@ -355,59 +364,44 @@ describe('sentiment-overview definitions', () => {
     // the live element (brand "au", week starting 2026-08-16), whose numbers the Semrush
     // MFE tooltip rendered as Negative 1% / 7, Neutral 56% / 571, Positive 43% / 443.
     describe('metric switch (prompts vs mentions)', () => {
-      // value = mentions, value__prompts = prompts — deliberately different, so a test
-      // reading the wrong field cannot pass by coincidence.
-      const rawWeek = {
-        type: 'bar',
-        blocks: {
-          data: [
-            {
-              bar: '2026-08-16', legend: 'Negative', value: 7, value__prompts: 7,
-            },
-            {
-              bar: '2026-08-16', legend: 'Neutral', value: 571, value__prompts: 208,
-            },
-            {
-              bar: '2026-08-16', legend: 'Positive', value: 443, value__prompts: 165,
-            },
-          ],
-          line: [{ bar: '2026-08-16', value: 275 }],
-        },
-      };
+      const rawWeek = RAW_SENTIMENT_WEEK;
       const pctOf = (wk) => Object.fromEntries(wk.sentiment.map((s) => [s.name, s.value]));
 
       it('defaults to prompts when no metric is given (unchanged behaviour)', () => {
         const res = transformSentimentOverviewResponse(rawWeek);
         expect(res.metric).to.equal('prompts');
-        expect(pctOf(res.weeklyTrends[0]))
-          .to.deep.equal({ Positive: 43, Neutral: 55, Negative: 2 });
-        expect(res.weeklyTrends[0].sentimentTotal).to.equal(380);
+        expect(pctOf(res.weeklyTrends[0])).to.deep.equal(SENTIMENT_PROMPTS_PCT);
+        expect(res.weeklyTrends[0].sentimentTotal).to.equal(SENTIMENT_PROMPTS_TOTAL);
       });
 
       it('reproduces the live MFE tooltip percentages when metric is mentions', () => {
         const res = transformSentimentOverviewResponse(rawWeek, { metric: 'mentions' });
         expect(res.metric).to.equal('mentions');
         // Exactly what the MFE showed for this bucket.
-        expect(pctOf(res.weeklyTrends[0]))
-          .to.deep.equal({ Positive: 43, Neutral: 56, Negative: 1 });
-        expect(res.weeklyTrends[0].sentimentTotal).to.equal(1021);
+        expect(pctOf(res.weeklyTrends[0])).to.deep.equal(SENTIMENT_MENTIONS_PCT);
+        expect(res.weeklyTrends[0].sentimentTotal).to.equal(SENTIMENT_MENTIONS_TOTAL);
+      });
+
+      it('normalises a padded/upper-case metric (shared with the controller)', () => {
+        const res = transformSentimentOverviewResponse(rawWeek, { metric: '  MENTIONS  ' });
+        expect(res.metric).to.equal('mentions');
+        expect(res.weeklyTrends[0].sentimentTotal).to.equal(SENTIMENT_MENTIONS_TOTAL);
       });
 
       it('falls back to prompts for an unrecognised or blank metric', () => {
         for (const metric of ['bogus', '', null, undefined, 42]) {
           const res = transformSentimentOverviewResponse(rawWeek, { metric });
           expect(res.metric, `metric=${metric}`).to.equal('prompts');
-          expect(res.weeklyTrends[0].sentimentTotal, `metric=${metric}`).to.equal(380);
+          expect(res.weeklyTrends[0].sentimentTotal, `metric=${metric}`)
+            .to.equal(SENTIMENT_PROMPTS_TOTAL);
         }
       });
 
       it('returns BOTH count sets regardless of the selected metric', () => {
         for (const metric of ['prompts', 'mentions']) {
           const [wk] = transformSentimentOverviewResponse(rawWeek, { metric }).weeklyTrends;
-          expect(wk.mentionCounts, `metric=${metric}`)
-            .to.deep.equal({ positive: 443, neutral: 571, negative: 7 });
-          expect(wk.promptCounts, `metric=${metric}`)
-            .to.deep.equal({ positive: 165, neutral: 208, negative: 7 });
+          expect(wk.mentionCounts, `metric=${metric}`).to.deep.equal(SENTIMENT_MENTION_COUNTS);
+          expect(wk.promptCounts, `metric=${metric}`).to.deep.equal(SENTIMENT_PROMPT_COUNTS);
         }
       });
 
@@ -416,7 +410,7 @@ describe('sentiment-overview definitions', () => {
       it('keeps promptsWithSentiment and totalPrompts prompt-based under either metric', () => {
         for (const metric of ['prompts', 'mentions']) {
           const [wk] = transformSentimentOverviewResponse(rawWeek, { metric }).weeklyTrends;
-          expect(wk.promptsWithSentiment, `metric=${metric}`).to.equal(380);
+          expect(wk.promptsWithSentiment, `metric=${metric}`).to.equal(SENTIMENT_PROMPTS_TOTAL);
           expect(wk.totalPrompts, `metric=${metric}`).to.equal(275);
         }
       });
@@ -435,6 +429,77 @@ describe('sentiment-overview definitions', () => {
             .to.deep.equal({ Positive: 0, Neutral: 0, Negative: 0 });
           expect(wk.sentimentTotal, `metric=${metric}`).to.equal(0);
         }
+      });
+
+      // The zero case above has BOTH sets empty. This is the asymmetric shape: the
+      // SELECTED basis is zero while the other is not — what an upstream `value`
+      // regression would look like, and what the controller's warn log keys on.
+      it('zeroes percentages when only the selected basis is empty', () => {
+        const mentionsMissing = {
+          blocks: {
+            data: [
+              {
+                bar: '2026-08-16', legend: 'Positive', value: 0, value__prompts: 165,
+              },
+              {
+                bar: '2026-08-16', legend: 'Neutral', value: 0, value__prompts: 208,
+              },
+            ],
+            line: [{ bar: '2026-08-16', value: 275 }],
+          },
+        };
+        const [asMentions] = transformSentimentOverviewResponse(mentionsMissing, { metric: 'mentions' }).weeklyTrends;
+        expect(pctOf(asMentions)).to.deep.equal({ Positive: 0, Neutral: 0, Negative: 0 });
+        expect(asMentions.sentimentTotal).to.equal(0);
+        // The other set is intact, which is exactly what makes this diagnosable.
+        expect(asMentions.promptCounts).to.deep.equal({ positive: 165, neutral: 208, negative: 0 });
+
+        const [asPrompts] = transformSentimentOverviewResponse(mentionsMissing, { metric: 'prompts' }).weeklyTrends;
+        expect(asPrompts.sentimentTotal).to.equal(373);
+      });
+
+      it('coerces a non-numeric mention value to 0 rather than NaN', () => {
+        const dirty = {
+          blocks: {
+            data: [
+              {
+                bar: '2026-08-16', legend: 'Positive', value: 'N/A', value__prompts: 10,
+              },
+              {
+                bar: '2026-08-16', legend: 'Neutral', value: 30, value__prompts: 10,
+              },
+            ],
+            line: [{ bar: '2026-08-16', value: 20 }],
+          },
+        };
+        const [wk] = transformSentimentOverviewResponse(dirty, { metric: 'mentions' }).weeklyTrends;
+        expect(wk.mentionCounts).to.deep.equal({ positive: 0, neutral: 30, negative: 0 });
+        expect(wk.sentimentTotal).to.equal(30);
+        expect(pctOf(wk)).to.deep.equal({ Positive: 0, Neutral: 100, Negative: 0 });
+      });
+
+      // The absorb branch: independent rounding of positive and negative can sum to
+      // 101, which would make the neutral remainder negative. Exercised on the
+      // mention path, which previously had no case for it.
+      it('clamps neutral to 0 on the mention path when rounding overflows to 101', () => {
+        const split = {
+          blocks: {
+            data: [
+              {
+                bar: '2026-08-16', legend: 'Positive', value: 101, value__prompts: 1,
+              },
+              {
+                bar: '2026-08-16', legend: 'Negative', value: 99, value__prompts: 1,
+              },
+            ],
+            line: [{ bar: '2026-08-16', value: 200 }],
+          },
+        };
+        const [wk] = transformSentimentOverviewResponse(split, { metric: 'mentions' }).weeklyTrends;
+        const pct = pctOf(wk);
+        expect(pct.Neutral).to.equal(0);
+        expect(pct.Positive + pct.Neutral + pct.Negative).to.equal(100);
+        expect(pct.Positive).to.be.at.least(pct.Negative);
       });
     });
   });

--- a/test/support/elements/definitions/sentiment-overview.test.js
+++ b/test/support/elements/definitions/sentiment-overview.test.js
@@ -232,7 +232,7 @@ describe('sentiment-overview definitions', () => {
 
   describe('transformSentimentOverviewResponse', () => {
     it('returns an empty weeklyTrends for a missing/empty response', () => {
-      const empty = { weeklyTrends: [] };
+      const empty = { metric: 'prompts', weeklyTrends: [] };
       expect(transformSentimentOverviewResponse(undefined)).to.deep.equal(empty);
       expect(transformSentimentOverviewResponse({ blocks: {} })).to.deep.equal(empty);
     });
@@ -349,6 +349,93 @@ describe('sentiment-overview definitions', () => {
       expect(weeklyTrends).to.have.length(1);
       expect(weeklyTrends[0].week).to.equal('2026-W11');
       expect(weeklyTrends.some((w) => /NaN/.test(w.week))).to.be.false;
+    });
+
+    // The `metric` switch (LLMO-7457). The fixture below is a REAL bucket captured from
+    // the live element (brand "au", week starting 2026-08-16), whose numbers the Semrush
+    // MFE tooltip rendered as Negative 1% / 7, Neutral 56% / 571, Positive 43% / 443.
+    describe('metric switch (prompts vs mentions)', () => {
+      // value = mentions, value__prompts = prompts — deliberately different, so a test
+      // reading the wrong field cannot pass by coincidence.
+      const rawWeek = {
+        type: 'bar',
+        blocks: {
+          data: [
+            {
+              bar: '2026-08-16', legend: 'Negative', value: 7, value__prompts: 7,
+            },
+            {
+              bar: '2026-08-16', legend: 'Neutral', value: 571, value__prompts: 208,
+            },
+            {
+              bar: '2026-08-16', legend: 'Positive', value: 443, value__prompts: 165,
+            },
+          ],
+          line: [{ bar: '2026-08-16', value: 275 }],
+        },
+      };
+      const pctOf = (wk) => Object.fromEntries(wk.sentiment.map((s) => [s.name, s.value]));
+
+      it('defaults to prompts when no metric is given (unchanged behaviour)', () => {
+        const res = transformSentimentOverviewResponse(rawWeek);
+        expect(res.metric).to.equal('prompts');
+        expect(pctOf(res.weeklyTrends[0]))
+          .to.deep.equal({ Positive: 43, Neutral: 55, Negative: 2 });
+        expect(res.weeklyTrends[0].sentimentTotal).to.equal(380);
+      });
+
+      it('reproduces the live MFE tooltip percentages when metric is mentions', () => {
+        const res = transformSentimentOverviewResponse(rawWeek, { metric: 'mentions' });
+        expect(res.metric).to.equal('mentions');
+        // Exactly what the MFE showed for this bucket.
+        expect(pctOf(res.weeklyTrends[0]))
+          .to.deep.equal({ Positive: 43, Neutral: 56, Negative: 1 });
+        expect(res.weeklyTrends[0].sentimentTotal).to.equal(1021);
+      });
+
+      it('falls back to prompts for an unrecognised or blank metric', () => {
+        for (const metric of ['bogus', '', null, undefined, 42]) {
+          const res = transformSentimentOverviewResponse(rawWeek, { metric });
+          expect(res.metric, `metric=${metric}`).to.equal('prompts');
+          expect(res.weeklyTrends[0].sentimentTotal, `metric=${metric}`).to.equal(380);
+        }
+      });
+
+      it('returns BOTH count sets regardless of the selected metric', () => {
+        for (const metric of ['prompts', 'mentions']) {
+          const [wk] = transformSentimentOverviewResponse(rawWeek, { metric }).weeklyTrends;
+          expect(wk.mentionCounts, `metric=${metric}`)
+            .to.deep.equal({ positive: 443, neutral: 571, negative: 7 });
+          expect(wk.promptCounts, `metric=${metric}`)
+            .to.deep.equal({ positive: 165, neutral: 208, negative: 7 });
+        }
+      });
+
+      // These two must not change meaning when the metric flips, or existing consumers
+      // would silently start reading a different quantity under the same field name.
+      it('keeps promptsWithSentiment and totalPrompts prompt-based under either metric', () => {
+        for (const metric of ['prompts', 'mentions']) {
+          const [wk] = transformSentimentOverviewResponse(rawWeek, { metric }).weeklyTrends;
+          expect(wk.promptsWithSentiment, `metric=${metric}`).to.equal(380);
+          expect(wk.totalPrompts, `metric=${metric}`).to.equal(275);
+        }
+      });
+
+      it('still emits percentages summing to 100 under mentions', () => {
+        const [wk] = transformSentimentOverviewResponse(rawWeek, { metric: 'mentions' }).weeklyTrends;
+        const total = wk.sentiment.reduce((sum, s) => sum + s.value, 0);
+        expect(total).to.equal(100);
+      });
+
+      it('zeroes percentages for a week with no sentiment under either metric', () => {
+        const emptyWeek = { blocks: { data: [], line: [{ bar: '2026-08-16', value: 0 }] } };
+        for (const metric of ['prompts', 'mentions']) {
+          const [wk] = transformSentimentOverviewResponse(emptyWeek, { metric }).weeklyTrends;
+          expect(pctOf(wk), `metric=${metric}`)
+            .to.deep.equal({ Positive: 0, Neutral: 0, Negative: 0 });
+          expect(wk.sentimentTotal, `metric=${metric}`).to.equal(0);
+        }
+      });
     });
   });
 });

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -1023,4 +1023,93 @@ describe('createElementsService', () => {
       expect(transport.fetchElement).to.have.been.calledTwice;
     });
   });
+
+  // Covers the controller -> service -> transform wiring seam for the `metric`
+  // param (LLMO-7457). The controller writes `metric:` into params and this
+  // service reads `params?.metric` back out; both ends are unit-tested in
+  // isolation, but nothing else asserts the key written matches the key read.
+  // Both sides also sit inside `c8 ignore` blocks, so a mismatch would make
+  // `metric=mentions` a permanent silent no-op with fully green CI — and the
+  // deliberately permissive parse removes the error path that would surface it.
+  describe('getSentimentOverview', () => {
+    // A real bucket captured from the live element (brand "au", week starting
+    // 2026-08-16), the same fixture the definition tests use. `value` and
+    // `value__prompts` differ deliberately, so reading the wrong field cannot
+    // pass by coincidence. The Semrush MFE rendered this bucket as
+    // Negative 1% / 7, Neutral 56% / 571, Positive 43% / 443.
+    const RAW_SENTIMENT = {
+      type: 'bar',
+      blocks: {
+        data: [
+          {
+            bar: '2026-08-16', legend: 'Negative', value: 7, value__prompts: 7,
+          },
+          {
+            bar: '2026-08-16', legend: 'Neutral', value: 571, value__prompts: 208,
+          },
+          {
+            bar: '2026-08-16', legend: 'Positive', value: 443, value__prompts: 165,
+          },
+        ],
+        line: [{ bar: '2026-08-16', value: 275 }],
+      },
+    };
+
+    const BASE_PARAMS = {
+      model: 'chatgpt',
+      startDate: '2026-08-11',
+      endDate: '2026-09-09',
+      brandName: 'au',
+    };
+
+    beforeEach(() => {
+      transport.fetchElement
+        .withArgs('ws-1', ELEMENT_IDS.SENTIMENT, sinon.match.any)
+        .resolves(RAW_SENTIMENT);
+    });
+
+    // Assertion 1: the metric the controller writes actually reaches the transform.
+    it('carries params.metric through to the transform (mentions)', async () => {
+      const params = { ...BASE_PARAMS, metric: 'mentions' };
+      const result = await service.getSentimentOverview('ws-1', params);
+      expect(result.metric).to.equal('mentions');
+      expect(result.weeklyTrends[0].sentimentTotal).to.equal(1021);
+      const pct = Object.fromEntries(
+        result.weeklyTrends[0].sentiment.map((s) => [s.name, s.value]),
+      );
+      expect(pct).to.deep.equal({ Positive: 43, Neutral: 56, Negative: 1 });
+    });
+
+    it('defaults to prompts when params carries no metric', async () => {
+      const result = await service.getSentimentOverview('ws-1', BASE_PARAMS);
+      expect(result.metric).to.equal('prompts');
+      expect(result.weeklyTrends[0].sentimentTotal).to.equal(380);
+    });
+
+    it('returns both count sets regardless of the metric', async () => {
+      for (const metric of ['prompts', 'mentions']) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await service.getSentimentOverview('ws-1', { ...BASE_PARAMS, metric });
+        const [wk] = result.weeklyTrends;
+        expect(wk.mentionCounts, `metric=${metric}`)
+          .to.deep.equal({ positive: 443, neutral: 571, negative: 7 });
+        expect(wk.promptCounts, `metric=${metric}`)
+          .to.deep.equal({ positive: 165, neutral: 208, negative: 7 });
+      }
+    });
+
+    // Assertion 2: `metric` is a presentation-only flag and must never reach
+    // Semrush. This holds today only because buildSentimentOverviewPayload
+    // destructures its params explicitly; nothing else enforces it, so a later
+    // refactor to a spread would start leaking an internal flag upstream.
+    it('sends an identical upstream payload for both metric values', async () => {
+      await service.getSentimentOverview('ws-1', { ...BASE_PARAMS, metric: 'prompts' });
+      await service.getSentimentOverview('ws-1', { ...BASE_PARAMS, metric: 'mentions' });
+
+      const [firstCall, secondCall] = transport.fetchElement.getCalls();
+      expect(secondCall.args[2]).to.deep.equal(firstCall.args[2]);
+      expect(JSON.stringify(firstCall.args[2])).to.not.contain('metric');
+      expect(firstCall.args[1]).to.equal(ELEMENT_IDS.SENTIMENT);
+    });
+  });
 });

--- a/test/support/elements/elements-service.test.js
+++ b/test/support/elements/elements-service.test.js
@@ -18,6 +18,14 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 import { createElementsService } from '../../../src/support/elements/elements-service.js';
 import { ELEMENT_IDS } from '../../../src/support/elements/element-ids.js';
 import {
+  RAW_SENTIMENT_WEEK,
+  SENTIMENT_MENTIONS_TOTAL,
+  SENTIMENT_PROMPTS_TOTAL,
+  SENTIMENT_MENTIONS_PCT,
+  SENTIMENT_MENTION_COUNTS,
+  SENTIMENT_PROMPT_COUNTS,
+} from './fixtures/sentiment-overview.js';
+import {
   DIMENSION,
   INTENT_VALUE,
   INTENT_ROOT_NAME,
@@ -1032,29 +1040,6 @@ describe('createElementsService', () => {
   // `metric=mentions` a permanent silent no-op with fully green CI — and the
   // deliberately permissive parse removes the error path that would surface it.
   describe('getSentimentOverview', () => {
-    // A real bucket captured from the live element (brand "au", week starting
-    // 2026-08-16), the same fixture the definition tests use. `value` and
-    // `value__prompts` differ deliberately, so reading the wrong field cannot
-    // pass by coincidence. The Semrush MFE rendered this bucket as
-    // Negative 1% / 7, Neutral 56% / 571, Positive 43% / 443.
-    const RAW_SENTIMENT = {
-      type: 'bar',
-      blocks: {
-        data: [
-          {
-            bar: '2026-08-16', legend: 'Negative', value: 7, value__prompts: 7,
-          },
-          {
-            bar: '2026-08-16', legend: 'Neutral', value: 571, value__prompts: 208,
-          },
-          {
-            bar: '2026-08-16', legend: 'Positive', value: 443, value__prompts: 165,
-          },
-        ],
-        line: [{ bar: '2026-08-16', value: 275 }],
-      },
-    };
-
     const BASE_PARAMS = {
       model: 'chatgpt',
       startDate: '2026-08-11',
@@ -1065,7 +1050,7 @@ describe('createElementsService', () => {
     beforeEach(() => {
       transport.fetchElement
         .withArgs('ws-1', ELEMENT_IDS.SENTIMENT, sinon.match.any)
-        .resolves(RAW_SENTIMENT);
+        .resolves(RAW_SENTIMENT_WEEK);
     });
 
     // Assertion 1: the metric the controller writes actually reaches the transform.
@@ -1073,17 +1058,25 @@ describe('createElementsService', () => {
       const params = { ...BASE_PARAMS, metric: 'mentions' };
       const result = await service.getSentimentOverview('ws-1', params);
       expect(result.metric).to.equal('mentions');
-      expect(result.weeklyTrends[0].sentimentTotal).to.equal(1021);
+      expect(result.weeklyTrends[0].sentimentTotal).to.equal(SENTIMENT_MENTIONS_TOTAL);
       const pct = Object.fromEntries(
         result.weeklyTrends[0].sentiment.map((s) => [s.name, s.value]),
       );
-      expect(pct).to.deep.equal({ Positive: 43, Neutral: 56, Negative: 1 });
+      expect(pct).to.deep.equal(SENTIMENT_MENTIONS_PCT);
     });
 
     it('defaults to prompts when params carries no metric', async () => {
       const result = await service.getSentimentOverview('ws-1', BASE_PARAMS);
       expect(result.metric).to.equal('prompts');
-      expect(result.weeklyTrends[0].sentimentTotal).to.equal(380);
+      expect(result.weeklyTrends[0].sentimentTotal).to.equal(SENTIMENT_PROMPTS_TOTAL);
+    });
+
+    // The transform shares its normaliser with the controller, so a direct service
+    // caller passing an un-normalised value resolves the same way an HTTP one does.
+    it('normalises a padded/upper-case metric from a direct service caller', async () => {
+      const result = await service.getSentimentOverview('ws-1', { ...BASE_PARAMS, metric: '  MENTIONS  ' });
+      expect(result.metric).to.equal('mentions');
+      expect(result.weeklyTrends[0].sentimentTotal).to.equal(SENTIMENT_MENTIONS_TOTAL);
     });
 
     it('returns both count sets regardless of the metric', async () => {
@@ -1091,10 +1084,8 @@ describe('createElementsService', () => {
         // eslint-disable-next-line no-await-in-loop
         const result = await service.getSentimentOverview('ws-1', { ...BASE_PARAMS, metric });
         const [wk] = result.weeklyTrends;
-        expect(wk.mentionCounts, `metric=${metric}`)
-          .to.deep.equal({ positive: 443, neutral: 571, negative: 7 });
-        expect(wk.promptCounts, `metric=${metric}`)
-          .to.deep.equal({ positive: 165, neutral: 208, negative: 7 });
+        expect(wk.mentionCounts, `metric=${metric}`).to.deep.equal(SENTIMENT_MENTION_COUNTS);
+        expect(wk.promptCounts, `metric=${metric}`).to.deep.equal(SENTIMENT_PROMPT_COUNTS);
       }
     });
 
@@ -1108,8 +1099,22 @@ describe('createElementsService', () => {
 
       const [firstCall, secondCall] = transport.fetchElement.getCalls();
       expect(secondCall.args[2]).to.deep.equal(firstCall.args[2]);
-      expect(JSON.stringify(firstCall.args[2])).to.not.contain('metric');
       expect(firstCall.args[1]).to.equal(ELEMENT_IDS.SENTIMENT);
+
+      // Assert on KEYS, recursively — a serialised-string check would false-positive
+      // on any nested VALUE that happened to contain the substring.
+      const collectKeys = (node, acc = []) => {
+        if (Array.isArray(node)) {
+          node.forEach((n) => collectKeys(n, acc));
+        } else if (node && typeof node === 'object') {
+          Object.keys(node).forEach((k) => {
+            acc.push(k);
+            collectKeys(node[k], acc);
+          });
+        }
+        return acc;
+      };
+      expect(collectKeys(firstCall.args[2])).to.not.include.members(['metric', 'sentimentMetric', 'sentiment_metric']);
     });
   });
 });

--- a/test/support/elements/fixtures/sentiment-overview.js
+++ b/test/support/elements/fixtures/sentiment-overview.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * A REAL Sentiment-element bucket captured from production (brand "au", week
+ * starting 2026-08-16), shared by the definition and service test suites so the
+ * two cannot drift apart (LLMO-7457).
+ *
+ * `value` (mentions) and `value__prompts` (prompts) are deliberately different,
+ * so a test that reads the wrong field cannot pass by coincidence.
+ *
+ * The Semrush Brand Presence MFE rendered this exact bucket as
+ * Negative 1% / 7, Neutral 56% / 571, Positive 43% / 443 — which is what makes
+ * SENTIMENT_MENTIONS_PCT below a reproduction of the vendor's own output rather
+ * than a number this codebase invented.
+ */
+export const RAW_SENTIMENT_WEEK = Object.freeze({
+  type: 'bar',
+  blocks: {
+    data: [
+      {
+        bar: '2026-08-16', legend: 'Negative', value: 7, value__prompts: 7,
+      },
+      {
+        bar: '2026-08-16', legend: 'Neutral', value: 571, value__prompts: 208,
+      },
+      {
+        bar: '2026-08-16', legend: 'Positive', value: 443, value__prompts: 165,
+      },
+    ],
+    line: [{ bar: '2026-08-16', value: 275 }],
+  },
+});
+
+/** Sum of the three mention counts — the denominator under `metric=mentions`. */
+export const SENTIMENT_MENTIONS_TOTAL = 1021;
+
+/** Sum of the three prompt counts — the denominator under the `prompts` default. */
+export const SENTIMENT_PROMPTS_TOTAL = 380;
+
+/** Percentages the MFE showed for this bucket; reproduced under `metric=mentions`. */
+export const SENTIMENT_MENTIONS_PCT = Object.freeze({ Positive: 43, Neutral: 56, Negative: 1 });
+
+/** Percentages this endpoint has always returned, under the `prompts` default. */
+export const SENTIMENT_PROMPTS_PCT = Object.freeze({ Positive: 43, Neutral: 55, Negative: 2 });
+
+/** Per-legend mention counts for the bucket. */
+export const SENTIMENT_MENTION_COUNTS = Object.freeze({ positive: 443, neutral: 571, negative: 7 });
+
+/** Per-legend prompt counts for the bucket. */
+export const SENTIMENT_PROMPT_COUNTS = Object.freeze({ positive: 165, neutral: 208, negative: 7 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

Adds an opt-in `metric` query parameter to the Serenity `brand-presence/sentiment-overview` endpoint, selecting whether the sentiment percentages are computed from the element's per-mention or per-prompt counts, and returns both raw count sets on every response.

## 2. Reasoning

A customer reported that the sentiment chart on Overview-SR disagreed with the one on the Semrush Brand Presence micro-frontend. The first cause — our request omitted the brand filter, so competitors were blended in — was fixed separately and is already in production.

With that fixed, both surfaces read the same data but still render it differently, because they count different things. The micro-frontend is owned by Semrush and cannot be changed, so ours has to move to match it. This change makes that move possible to verify before it is adopted.

The evidence is a micro-frontend tooltip for brand `au`, bucket beginning 2026-08-16, showing Negative 1% / 7, Neutral 56% / 571, Positive 43% / 443:

- Those counts match the element row's mention field exactly. The prompt field for the same row is 7 / 208 / 165 and does not match. So the micro-frontend plots mentions.
- Its percentages are each value over the sum of the three, which reproduces 1 / 56 / 43 exactly. The alternative denominator — the distinct-response line total for that bucket — would produce 3 / 208 / 161, so it is definitively not what Semrush uses.

That second point settles a question the ticket originally raised. The overlapping-legend sum is **not** a defect to correct: Semrush normalises the same way we already do. Only the field being read differs, and our existing rounding rule applied to mentions reproduces the micro-frontend's output exactly.

**Why a parameter rather than changing the behaviour outright, or adding an endpoint.** No org in the dev environment is correctly connected to Semrush, so this cannot be verified there — production is the only place the two definitions can be compared. A parameter makes that comparison possible without exposing customers to the change. A second endpoint was considered and rejected: it would need its own route, OpenAPI path, controller, service method and integration-test scaffolding, plus a migration and a deletion, for a change that alters no response shape.

## 3. High-level overview of the changes

**Nothing changes for any existing caller.** The parameter defaults to the current behaviour, so deploying this is a no-op until a caller opts in.

- `?metric=prompts` (default) — percentages from the per-prompt counts, exactly as today.
- `?metric=mentions` — percentages from the per-mention counts, matching the micro-frontend.

Unrecognised, blank and absent values all resolve to `prompts` rather than returning a 400. This is deliberate: an unknown value should degrade to today's numbers rather than fail an otherwise-valid chart request. `sentimentMetric` and `sentiment_metric` are accepted as aliases, following the existing convention on this controller.

The request payload sent upstream is unchanged. The element already returns both counts on every row, so this only selects which one the transform reads.

Additive response fields, returned regardless of the parameter:

- `mentionCounts` and `promptCounts` — the raw per-sentiment counts for the week.
- `sentimentTotal` — the denominator the percentages were computed over.
- `metric` — the resolved value, echoed back so a caller can confirm which definition it received.

Because they are additive, neither existing consumer can break. They also mean a caller can render true counts beside the percentages, as the micro-frontend does, instead of reconstructing them from `percentage x promptsWithSentiment` — which is lossy and is what the Overview-SR adapter does today. And both definitions can be compared from a single call.

`promptsWithSentiment` and `totalPrompts` stay prompt-based under either setting, so no existing field changes meaning.

Illustrative effect on the reported brand, once a caller opts in: positive moves by 0-2 points and negative settles at 1% (from 2-3%), because the mention denominator is substantially larger.

This parameter is **temporary**. The default flips to `mentions` and the `prompts` branch is removed once the UI has migrated.

## 4. Required information

- Jira / issue: [LLMO-7457](https://jira.corp.adobe.com/browse/LLMO-7457) — carries the full design of record, including the measured evidence and the rejected alternatives
- Other: [LLMO-7456](https://jira.corp.adobe.com/browse/LLMO-7456) — the parent brand-scoping fix, already merged and live

## 6. Affected / used mysticat-workspace projects

- `project-elmo-ui` — consumed / contract. Two screens read this endpoint: the Overview-SR sentiment chart and the Brand Presence SR dashboard. Neither changes as a result of this PR, because the default preserves current behaviour. The follow-up frontend change will opt Overview-SR in and render the new counts in the chart tooltip; whether the Brand Presence SR dashboard also adopts `mentions` is a separate, deliberate decision.

## 7. Additional information outside the code

- The target values were established from a live micro-frontend tooltip on the reporting customer's brand, cross-checked against the raw element rows captured for the same bucket. Both candidate denominators were computed against that tooltip; only the sum-of-three reproduces it, which is what rules the alternative out rather than leaving it an open question.
- The transform was exercised against that same real bucket to confirm the default path is byte-identical to current behaviour and the opt-in path reproduces the tooltip percentages.
- `docs/index.html` is deliberately **not** regenerated in this PR. Per this repo's guidance, `docs:build` rewrites that file's hashed CSS class names non-deterministically outside the canonical CI toolchain, producing a very large diff that is pure hash churn rather than content. The OpenAPI spec files are the source of truth and are updated here; they are what reviewers should verify.
- Worth flagging for anyone picking this branch up: the worktree's copied `node_modules` was missing `@aws-sdk/client-dynamodb`, a peer dependency this repo does not declare directly. It surfaced as an unrelated suite failure until a fresh install. Not caused by this change, and no lockfile change resulted.

## 8. Test plan

**(a) Local verification beyond automated tests**

The transform was driven against a real element bucket captured from production, with the mention and prompt fields deliberately different so a wrong-field read cannot pass by coincidence. The default path returns the current percentages; the opt-in path returns the percentages the micro-frontend displayed for that same bucket.

**(b) Per-environment verification**

Dev and stage cannot verify this — no org there is correctly connected to Semrush. That constraint is the reason for the parameter.

Production, after deploy — read-only, no customer impact:

1. Call the endpoint with no `metric` for a brand with sentiment data. Confirm the response is unchanged from before this deploy. This is the safety check that matters most, since the default path is what every current caller hits.
2. Call the same range with `?metric=mentions`. Confirm the percentages match what the Semrush Brand Presence micro-frontend shows for that brand and range, and that `metric` is echoed as `mentions`.
3. Confirm `mentionCounts`, `promptCounts` and `sentimentTotal` are present on both calls, and that `promptsWithSentiment` and `totalPrompts` are identical between them.
4. Call with a nonsense value such as `?metric=banana` and confirm it returns the default numbers rather than an error.

## 9. Deployment & merge order

This PR is independently deployable and safe to merge on its own — the default preserves existing behaviour, so it changes nothing on release.

It is, however, step one of a sequence:

1. **This PR** — backend parameter and counts. No user-visible change.
2. Verify both definitions in production, as described in the test plan.
3. Frontend (`project-elmo-ui`) — Overview-SR opts in to `metric=mentions` and renders counts in the tooltip. Depends on this PR being deployed.
4. Cleanup — flip the default to `mentions`, remove the parameter and the `prompts` branch. Depends on step 3.

Step 4 must not be skipped. Leaving both definitions in place indefinitely is the outcome that avoiding a second endpoint was meant to prevent.

🤖 Generated with [review-kit](https://github.com/adobe/experience-success-skills)
