### PR TITLE
feat(serenity): add paginated Brand Claims response feed

### DIFF
--- a/docs/elements/semrush-elements-api-reference.md
+++ b/docs/elements/semrush-elements-api-reference.md
@@ -141,7 +141,8 @@ Single method: `fetchElement(workspaceId, elementId, payload)`.
 - Reads base URL from `env.SEMRUSH_PROJECTS_BASE_URL` (same secret used by the Serenity transport)
 - Enforces HTTPS — throws `ErrorWithStatusCode(503)` if misconfigured
 - Authenticates with the caller's IMS bearer token forwarded unchanged
-- `AbortController` timeout at 15 seconds — throws `ElementsTransportError(504)` on timeout
+- `AbortController` timeout defaults to 30 seconds and covers response headers plus complete body consumption — throws `ElementsTransportError(504)` on timeout
+- Brand Claims overrides this to 20 seconds with no in-request 429 retry, keeping the synchronous route below API Gateway's integration ceiling; the consumer retries a failed page as a separate bounded request
 - Parses response body as JSON (falls back to raw text)
 - Throws `ElementsTransportError(status, message, body)` for non-2xx responses
 

--- a/docs/elements/semrush-elements-api-reference.md
+++ b/docs/elements/semrush-elements-api-reference.md
@@ -358,7 +358,7 @@ Follow these steps in order. Steps 1–4 are contained within `src/support/eleme
    export function buildMyNewElementPayload({ ...params }) {
      return { /* Semrush payload shape */ };
    }
-   
+
    export function transformMyNewElementResponse(raw) {
      return (raw?.blocks?.data ?? []).map(item => ({ /* typed fields */ }));
    }
@@ -464,6 +464,8 @@ Upstream error bodies are **never forwarded to clients** — they are logged ser
 | `SEMRUSH_PROJECTS_BASE_URL` | Vault `dx_mysticat/<env>/api-service` | `elements-transport.js` `baseUrl()` — the Elements API base host (e.g. `https://www.semrush.com`) for regular (IMS-authenticated) callers |
 | `SEO_API_BASE_URL` | Vault `dx_mysticat/<env>/api-service` | `elements-transport.js` `s2sBaseUrl()` — the v4-raw external-api host (`https://api.semrush.com`) used for S2S-consumer calls |
 | `SEMRUSH_ADMIN_ELEMENT_API_KEY` | Vault `dx_mysticat/<env>/api-service` | `elements-transport.js` `buildS2SHeaders()` — the `Apikey` credential used to authenticate S2S-consumer calls to the Elements API |
+| `BRAND_CLAIMS_MAX_UPSTREAM_BYTES` | Optional environment override; default 8 MiB | Maximum decompressed `55e89619` response body read before the transport cancels and fails with 502 |
+| `BRAND_CLAIMS_MAX_OUTBOUND_BYTES` | Optional environment override; default 5 MiB | Maximum serialized Brand Claims API envelope before the controller fails with 502 |
 
 The Elements transport reuses the same `SEMRUSH_PROJECTS_BASE_URL` already configured for the Serenity (prompts/markets) transport for regular callers. S2S consumers (see [S2S Elements Access](#s2s-elements-access) below) use a different upstream gateway and credential entirely.
 

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -13091,122 +13091,68 @@ SerenityBrandPresenceSubredditRow:
       description: Semrush project the row belongs to.
       example: 'cb4f6443-e01f-4075-a586-85511f136e31'
 
-SerenityBrandPresenceResponseFeedSource:
-  type: object
-  description: |
-    One source cited by an AI answer.
-
-    Ordered within `sources` by `rank`, which is the element's AGGREGATE ranking for
-    that domain — NOT the position the citation occupied inline in the answer text.
-    True inline citation order is not available upstream; do not present this as
-    citation order.
-  required: [url, domain, rank, domainType]
-  properties:
-    url:
-      type: string
-      description: Cited URL.
-      example: 'https://www.runnersworld.com/gear/best-running-shoes'
-    domain:
-      type: string
-      description: Display/domain form of the source.
-      example: 'runnersworld.com'
-    rank:
-      type: integer
-      description: Aggregate ranking from the element (see the ordering caveat above).
-      example: 1
-    domainType:
-      type: string
-      description: Semrush domain classification.
-      example: 'Earned'
-
 SerenityBrandPresenceResponseFeedRecord:
   type: object
-  description: |
-    One AI answer with the sources cited in that same execution, keyed by
-    `(projectId, prompt, model, date)`.
-
-    `model` and `date` are always present and are load-bearing: the downstream consumer
-    keys on `(prompt, region)` and carries neither dimension, so it cannot reconstruct
-    them. An empty `sources` array means that execution cited nothing — never that
-    sources were lost.
-  required: [projectId, prompt, model, date, response, sources, sourceCount]
+  additionalProperties: false
+  required: [projectId, prompt, response, date, model, responses, sources, tags]
   properties:
     projectId:
       type: string
-      description: Semrush project (one per market).
-      example: '460e0a7b-b8db-44f4-8b16-0e1bd1241efa'
-    prompt:
-      type: string
-      example: 'best running shoes for flat feet'
+      description: Server-resolved Semrush project for the selected market.
+    prompt: { type: string, minLength: 1 }
+    response: { type: string, minLength: 1 }
+    date: { type: string, format: date }
     model:
       type: string
-      description: AI model that produced the answer.
-      example: 'chatgpt-paid'
-    date:
-      type: string
-      format: date
-      description: Calendar day of the execution (YYYY-MM-DD).
-      example: '2026-08-24'
-    response:
-      type: string
-      description: The answer text.
+      enum: [search-gpt]
+    responses:
+      type: integer
+      minimum: 0
     sources:
       type: array
-      items:
-        $ref: '#/SerenityBrandPresenceResponseFeedSource'
-    sourceCount:
-      type: integer
       description: |
-        Number of source rows joined to this answer. Exposed so a caller can spot an
-        implausible fan-out if the one-execution-per-tuple invariant were violated
-        upstream.
-      example: 3
+        Per-execution source URLs in upstream order. Order is load-bearing because current
+        Claims numeric citations resolve by source-array index; never sort or deduplicate.
+      items: { type: string }
+    tags:
+      type: array
+      items: { type: string }
+
+SerenityBrandPresenceResponseFeedPage:
+  type: object
+  additionalProperties: false
+  required: [offset, pageSize, returned, rowCount, nextOffset]
+  properties:
+    offset: { type: integer, minimum: 0 }
+    pageSize: { type: integer, minimum: 1, maximum: 500 }
+    returned: { type: integer, minimum: 0, maximum: 500 }
+    rowCount: { type: integer, minimum: 0 }
+    nextOffset:
+      type: [integer, 'null']
+      minimum: 0
+
+SerenityBrandPresenceResponseFeedSlice:
+  type: object
+  additionalProperties: false
+  required: [geoTargetId, languageCode, date, model]
+  properties:
+    geoTargetId: { type: integer, minimum: 1 }
+    languageCode: { type: string, minLength: 1 }
+    date: { type: string, format: date }
+    model:
+      type: string
+      enum: [search-gpt]
 
 SerenityBrandPresenceResponseFeed:
   type: object
-  description: |
-    Brand Claims response feed for the requested days: each AI answer paired with the
-    sources cited in the same execution.
-
-    `truncated` and `unmatchedSourceKeyCount` exist so a consumer can tell an incomplete
-    read from a genuinely quiet day — the distinction the feed depends on, since a
-    missing tuple is normally legitimate.
-  required: [records, totalCount, days, projectIds, pageSize, truncated, unmatchedSourceKeyCount]
+  additionalProperties: false
+  required: [data, page, slice]
   properties:
-    records:
+    data:
       type: array
-      items:
-        $ref: '#/SerenityBrandPresenceResponseFeedRecord'
-    totalCount:
-      type: integer
-      example: 42
-    days:
-      type: array
-      description: Calendar days covered, oldest first.
-      items: { type: string, format: date }
-      example: ['2026-08-23', '2026-08-24']
-    projectIds:
-      type: array
-      description: Projects (markets) scoped to. Empty means workspace-wide.
-      items: { type: string }
-    pageSize:
-      type: integer
-      description: Upstream page size actually used, after clamping.
-      example: 5000
-    truncated:
-      type: boolean
-      description: |
-        True when at least one upstream page came back full, so the window may be
-        clipped and this day's set incomplete. A consumer seeing this should narrow the
-        range rather than treat the result as whole.
-      example: false
-    unmatchedSourceKeyCount:
-      type: integer
-      description: |
-        Source rows whose answer was not present in the same page. Normally 0; a
-        persistently high value means the two elements disagreed and the join is losing
-        citations.
-      example: 0
+      items: { $ref: '#/SerenityBrandPresenceResponseFeedRecord' }
+    page: { $ref: '#/SerenityBrandPresenceResponseFeedPage' }
+    slice: { $ref: '#/SerenityBrandPresenceResponseFeedSlice' }
 
 SerenityBrandPresenceSubreddits:
   type: object

--- a/docs/openapi/serenity-api.yaml
+++ b/docs/openapi/serenity-api.yaml
@@ -1785,127 +1785,69 @@ v2-serenity-brand-presence-responses:
       in: path
       required: true
       description: SpaceCat Organization ID (UUID)
-      schema:
-        type: string
-        format: uuid
+      schema: { type: string, format: uuid }
     - name: brandId
       in: path
       required: true
       description: Brand ID (UUID-only on the /serenity/* surface)
-      schema:
-        type: string
-        format: uuid
+      schema: { type: string, format: uuid }
   get:
     tags: [serenity]
-    summary: Brand Claims response feed — AI answers paired with the sources cited in the same execution
+    summary: One paginated market slice of Brand Claims responses
     description: |
-      Returns one record per AI answer for each day in the range, carrying that
-      execution's own cited sources. Brand Claims sits under Brand Presence within the
-      ABV product.
-
-      Assembled from two Semrush elements that each hold half the record: `141adc88`
-      has the answer text but no date, `404fb017` has the date and the cited URLs but
-      no answer. They are joined on `(project_id, prompt, model, date)`, which is sound
-      because at most one execution exists per that tuple (measured: 2,553 tuples, each
-      mapping to exactly one execution id).
-
-      Brand-scoped via the brand's Semrush sub-workspace, resolved from `:brandId` — the
-      caller never supplies a workspace and never holds a Semrush credential.
-
-      **Range-based by design.** The upstream window is bounded above only, so a single
-      day is recovered as the difference between two pulls. Consecutive days share a
-      boundary, so an N-day range costs N+1 upstream pulls per element rather than 2N.
-
-      **Absence is meaningful.** A `(prompt, model)` tuple runs on roughly 61 of 74 days
-      in practice; some models far fewer. A missing tuple means that model did not run
-      that day — never an error, and never lost data. An answer that cited nothing is
-      returned with an empty `sources` array rather than omitted.
-
-      **Ordering caveat.** `sources` is ordered by the element's aggregate `rank`, which
-      is NOT the order the sources appeared inline in the answer. True inline citation
-      order is not available upstream; do not present this as citation order.
+      Returns one page from combined Semrush element `55e89619` for exactly one
+      brand-owned market, one selected Monday, and model `search-gpt`. The service
+      resolves the brand sub-workspace and Semrush project; callers cannot supply either.
+      `rowCount` is the upstream corpus count and `nextOffset` is null exactly when the
+      returned page reaches it. Source order is preserved exactly because current Claims
+      numeric citations resolve by source-array index.
     operationId: listSerenityBrandPresenceResponses
     security:
       - session_token: []
     parameters:
-      - name: from
+      - name: geoTargetId
         in: query
-        required: false
-        description: |
-          Inclusive range start (YYYY-MM-DD). Alias `startDate`. Defaults to 7 days
-          before `to`. The span must be under 74 days — the upstream window is rolling
-          and older executions are unrecoverable, so a wider request is rejected rather
-          than served as an empty result.
+        required: true
+        description: Geo target of one market owned by the brand.
+        schema: { type: integer, minimum: 1 }
+      - name: languageCode
+        in: query
+        required: true
+        description: Language code paired with geoTargetId in the brand market mapping.
+        schema: { type: string, minLength: 1 }
+      - name: date
+        in: query
+        required: true
+        description: Exact selected Monday.
         schema: { type: string, format: date }
-      - name: to
+      - name: offset
         in: query
         required: false
-        description: |
-          Inclusive range end (YYYY-MM-DD). Alias `endDate`. Defaults to yesterday —
-          today's executions are still landing, so ending on today would report a
-          partial day as though complete.
-        schema: { type: string, format: date }
-      - name: startDate
+        schema: { type: integer, minimum: 0, default: 0 }
+      - name: pageSize
         in: query
         required: false
-        description: Alias for `from`; `from` takes precedence when both are given.
-        schema: { type: string, format: date }
-      - name: endDate
-        in: query
-        required: false
-        description: Alias for `to`; `to` takes precedence when both are given.
-        schema: { type: string, format: date }
-      - name: model
-        in: query
-        required: false
-        description: |
-          AI model to scope to. Accepts a Semrush Elements model name directly, or a
-          UI platform code which is translated server-side.
-        schema: { type: string }
-      - name: platform
-        in: query
-        required: false
-        description: Legacy alias for `model`; `model` takes precedence when both are given.
-        schema: { type: string }
-      - name: projectId
-        in: query
-        required: false
-        description: |
-          Comma-separated Semrush project UUIDs (one project per market). Alias
-          `project_id`. Omitted → all of the brand's markets. Each id must be a valid
-          UUID (400 otherwise) and must be owned by this brand (403 otherwise).
-        schema: { type: string, pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(,[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}){0,7}$' }
-      - name: project_id
-        in: query
-        required: false
-        description: Snake_case alias for `projectId`.
-        schema: { type: string }
-      - name: limit
-        in: query
-        required: false
-        description: |
-          Upstream page size, clamped to 1..20000 (default 5000). 20000 is the largest
-          page that works on both upstream routes. Raising this is preferable to paging,
-          because every upstream call re-scans the whole rolling window.
-        schema: { type: integer, minimum: 1, maximum: 20000, default: 5000 }
+        schema: { type: integer, minimum: 1, maximum: 500, default: 500 }
     responses:
       '200':
-        description: Response feed retrieved.
+        description: Response page retrieved.
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityBrandPresenceResponseFeed' }
       '400': { $ref: './responses.yaml#/400' }
       '403':
-        description: Caller lacks access to the organization, or a supplied projectId is not owned by the brand.
+        description: Caller lacks access to the organization or brand.
       '404':
-        description: Organization not found, brand not found for this organization, serenity is not active for the brand, or the brand has no resolvable Semrush workspace.
+        description: Organization, brand, sub-workspace, or owned market was not found.
+      '409':
+        description: More than one owned project maps to the requested market.
       '502':
-        description: Upstream returned a non-2xx response.
+        description: Upstream request or response validation failed.
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }
       '503':
-        description: PostgREST client not available (required to resolve the brand's Semrush workspace before the element call).
+        description: Required data access or upstream credential configuration is unavailable.
         content:
           application/json:
             schema: { $ref: './schemas.yaml#/SerenityErrorResponse' }

--- a/src/controllers/elements.js
+++ b/src/controllers/elements.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { createHash } from 'node:crypto';
 import {
   badRequest, createResponse, forbidden, internalServerError, notFound, ok,
 } from '@adobe/spacecat-shared-http-utils';
@@ -41,18 +42,15 @@ const BEARER_PREFIX = 'Bearer ';
 // mapWithConcurrency itself lives in support/elements/concurrency.js (shared with the service).
 const FANOUT_CONCURRENCY = 8;
 
-/** Milliseconds in a day, for span arithmetic on `YYYY-MM-DD` bounds. */
-const MS_PER_DAY = 86400000;
-
-/**
- * Maximum span the response feed will serve, in days.
- *
- * The upstream window is ROLLING and about 74 days wide (measured 2026-09-04). Beyond it a
- * day is UNRECOVERABLE rather than expensive, and the failure is silent: the upstream
- * returns nothing for an out-of-window day, which is indistinguishable from "no model ran".
- * Rejecting at the edge keeps that ambiguity out of the response.
- */
-const RESPONSE_FEED_MAX_SPAN_DAYS = 74;
+const BRAND_CLAIMS_PAGE_SIZE = 500;
+// Defaults stay below Lambda's 6 MiB synchronous response ceiling while leaving room above
+// the largest measured 500-row upstream page (~2.5 MB). Environment overrides allow deployed
+// ceilings to be lowered without changing the contract.
+const BRAND_CLAIMS_MAX_UPSTREAM_BYTES = 8 * 1024 * 1024;
+const BRAND_CLAIMS_MAX_OUTBOUND_BYTES = 5 * 1024 * 1024;
+const BRAND_CLAIMS_QUERY_KEYS = new Set([
+  'geoTargetId', 'languageCode', 'date', 'offset', 'pageSize',
+]);
 
 /**
  * Maps a BrandSemrushProject model instance to the plain object shape the
@@ -64,6 +62,7 @@ function toPlainProject(p) {
     semrushProjectId: p.getSemrushProjectId(),
     geoTargetId: p.getGeoTargetId(),
     languageCode: p.getLanguageCode(),
+    deletedAt: p.getDeletedAt?.() ?? null,
   };
 }
 
@@ -140,6 +139,21 @@ function reqCtxOf(ctx) {
   };
 }
 
+function configuredByteLimit(env, name, fallback) {
+  const raw = env?.[name];
+  if (raw === undefined || raw === null || raw === '') {
+    return fallback;
+  }
+  if (!/^\d+$/.test(String(raw))) {
+    throw new ErrorWithStatusCode(`${name} must be a positive integer`, 503);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new ErrorWithStatusCode(`${name} must be a positive integer`, 503);
+  }
+  return parsed;
+}
+
 function mapError(e, log, reqCtx = {}) {
   if (e instanceof ErrorWithStatusCode) {
     const status = Number.isInteger(e.status) ? e.status : 400;
@@ -202,6 +216,25 @@ function extractQuery(context) {
     } catch { /* fall through */ }
   }
   return {};
+}
+
+function brandClaimsReqCtx(ctx) {
+  const query = extractQuery(ctx);
+  const brandId = ctx?.params?.brandId;
+  return {
+    requestId: ctx?.invocation?.id || 'unknown',
+    brandIdHash: hasText(brandId)
+      ? createHash('sha256').update(brandId).digest('hex').slice(0, 12)
+      : undefined,
+    geoTargetId: /^\d{1,10}$/.test(query.geoTargetId ?? '')
+      ? Number(query.geoTargetId)
+      : undefined,
+    languageCode: /^[A-Za-z0-9-]{1,20}$/.test(query.languageCode ?? '')
+      ? query.languageCode
+      : undefined,
+    offset: /^\d{1,16}$/.test(query.offset ?? '') ? Number(query.offset) : 0,
+    isS2SConsumer: AccessControlUtil.isS2SConsumer(ctx),
+  };
 }
 
 function tagFilterParams(query) {
@@ -2447,87 +2480,122 @@ export default function ElementsController(context, log, env) {
   /* c8 ignore stop */
 
   /**
-   * GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/responses
-   *
-   * The Brand Claims RESPONSE FEED: each AI answer for the requested days, paired with the
-   * sources cited in that same execution. Brand Claims sits under Brand Presence within the
-   * ABV product, hence the path segment.
-   *
-   * Assembled from two elements that each hold half the record — 141adc88 has the answer but
-   * no date, 404fb017 has the date and citations but no answer — joined on
-   * `(project_id, prompt, model, date)`. See `elements-service.js#getResponseFeed`.
-   *
-   * RANGE-BASED BY DESIGN. Consecutive days share a window boundary, so N days cost N+1
-   * upstream pulls rather than 2N. A per-day endpoint would forfeit that and pay double.
+   * Returns one page of one owned market's combined Brand Claims execution corpus.
+   * The caller selects a market by geo/language; project and workspace identifiers remain
+   * server-side. Model is fixed to search-gpt and date must be an exact Monday.
    */
   const listResponseFeed = async (ctx) => {
     try {
-      const auth = await authorizeOrg(ctx);
+      const auth = await authorizeBrandSubWorkspace(ctx, log);
       if (auth.error) {
         return auth.error;
       }
-      // authorizeOrg validated `:brandId`, confirmed the brand belongs to the org, and
-      // resolved the brand's Semrush sub-workspace. The caller never supplies a workspace
-      // id and never holds a Semrush credential (design of record §10).
-      const { workspaceId, brand } = auth;
+      const { workspaceId, brandUuid } = auth;
       const query = extractQuery(ctx);
-
-      // Default to the last 7 days ending yesterday. Yesterday, not today: the upstream
-      // window is bounded by `CBF_date__end` and today's executions are still landing, so
-      // ending on today would report a partial day as though it were complete. Seven days
-      // is a working week of context at 8 boundary pulls per market — small enough to stay
-      // responsive, wide enough to be useful without a caller computing dates.
-      const defaultEnd = addDaysToDate(new Date().toISOString().slice(0, 10), -1);
-      const startDate = query.from || query.startDate || addDaysToDate(defaultEnd, -6);
-      const endDate = query.to || query.endDate || defaultEnd;
-
-      if (!isYmdDate(startDate) || !isYmdDate(endDate)) {
-        return badRequest('from and to must be valid YYYY-MM-DD dates');
-      }
-      if (startDate > endDate) {
-        return badRequest('from must not be after to');
+      const unsupported = Object.keys(query).filter((key) => !BRAND_CLAIMS_QUERY_KEYS.has(key));
+      if (unsupported.length > 0) {
+        return badRequest(`Unsupported query parameter: ${unsupported[0]}`);
       }
 
-      // The upstream window is ROLLING and about 74 days wide (measured 2026-09-04). A day
-      // older than that is UNRECOVERABLE, not merely expensive — the data is gone upstream.
-      // Rejecting is essential: serving such a request would return an empty result that is
-      // indistinguishable from "nothing ran", i.e. silent data loss presented as fact.
-      const spanDays = (Date.parse(`${endDate}T00:00:00Z`)
-        - Date.parse(`${startDate}T00:00:00Z`)) / MS_PER_DAY;
-      if (spanDays >= RESPONSE_FEED_MAX_SPAN_DAYS) {
-        return badRequest(
-          `Date range must not exceed ${RESPONSE_FEED_MAX_SPAN_DAYS} days: the upstream window `
-          + 'is rolling and older executions are unrecoverable',
+      const { geoTargetId, languageCode, date } = query;
+      if (!/^\d+$/.test(geoTargetId ?? '') || Number(geoTargetId) <= 0) {
+        return badRequest('geoTargetId must be a positive integer');
+      }
+      if (!hasText(languageCode) || languageCode.trim() !== languageCode) {
+        return badRequest('languageCode is required');
+      }
+      if (!isYmdDate(date)) {
+        return badRequest('date must be a valid YYYY-MM-DD date');
+      }
+      if (new Date(`${date}T00:00:00Z`).getUTCDay() !== 1) {
+        return badRequest('date must be a Monday');
+      }
+
+      const parseInteger = (value, fallback, min, max, name) => {
+        if (value === undefined) {
+          return fallback;
+        }
+        if (!/^\d+$/.test(value)) {
+          throw new ErrorWithStatusCode(`${name} must be an integer`, 400);
+        }
+        const parsed = Number(value);
+        if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+          throw new ErrorWithStatusCode(`${name} must be between ${min} and ${max}`, 400);
+        }
+        return parsed;
+      };
+      const offset = parseInteger(query.offset, 0, 0, Number.MAX_SAFE_INTEGER, 'offset');
+      const pageSize = parseInteger(query.pageSize, BRAND_CLAIMS_PAGE_SIZE, 1, BRAND_CLAIMS_PAGE_SIZE, 'pageSize');
+
+      const { BrandSemrushProject } = ctx.dataAccess;
+      const projects = await fetchBrandSemrushProjects(BrandSemrushProject, [{ id: brandUuid }]);
+      const normalizedLanguage = languageCode.toLowerCase();
+      const matches = projects.filter((project) => project.brandId === brandUuid
+        && project.deletedAt === null
+        && Number(project.geoTargetId) === Number(geoTargetId)
+        && String(project.languageCode ?? '').toLowerCase() === normalizedLanguage
+        && hasText(project.semrushProjectId));
+      if (matches.length === 0) {
+        return notFound('No owned Semrush project matches the requested market');
+      }
+      if (matches.length > 1) {
+        return createResponse({
+          error: 'ambiguousMarket',
+          message: 'Multiple owned Semrush projects match the requested market',
+        }, 409);
+      }
+
+      const maxUpstreamBytes = configuredByteLimit(
+        env,
+        'BRAND_CLAIMS_MAX_UPSTREAM_BYTES',
+        BRAND_CLAIMS_MAX_UPSTREAM_BYTES,
+      );
+      const maxOutboundBytes = configuredByteLimit(
+        env,
+        'BRAND_CLAIMS_MAX_OUTBOUND_BYTES',
+        BRAND_CLAIMS_MAX_OUTBOUND_BYTES,
+      );
+      const service = await buildService(ctx);
+      const project = matches[0];
+      const result = await service.getResponseFeed(workspaceId, {
+        projectId: project.semrushProjectId,
+        date,
+        offset,
+        pageSize,
+        maxUpstreamBytes,
+      });
+      const envelope = ResponseFeedDto.toEnvelopeJSON({
+        ...result,
+        slice: {
+          geoTargetId: Number(project.geoTargetId),
+          languageCode: project.languageCode,
+          date,
+          model: 'search-gpt',
+        },
+      });
+      if (new TextEncoder().encode(JSON.stringify(envelope)).byteLength > maxOutboundBytes) {
+        throw new ElementsTransportError(
+          502,
+          `Brand Claims response exceeds configured ${maxOutboundBytes}-byte limit`,
         );
       }
-
-      const service = await buildService(ctx);
-
-      // Project scoping: caller-supplied projectId(s) (CSV) scope to those Semrush projects;
-      // absent → all of the brand's markets. LOAD-BEARING: the technical account is broadly
-      // entitled, so a caller who guessed another brand's project UUID could otherwise read
-      // that tenant's answers. Ownership is checked against this brand's own rows.
-      const projectIds = extractProjectIds(query);
-      // `dataAccess` is guaranteed present here — `authorizeOrg` above already read
-      // `Organization` from it — so this is a plain destructure rather than the optional
-      // form the sibling handlers use, whose fallback branch is unreachable in practice.
-      const { BrandSemrushProject } = ctx.dataAccess;
-      const brandSemrushProjects = await fetchBrandSemrushProjects(BrandSemrushProject, [brand]);
-      const ownershipError = checkProjectIdsOwnership(projectIds, brandSemrushProjects);
-      if (ownershipError) {
-        return ownershipError;
-      }
-
-      const result = await service.getResponseFeed(workspaceId, {
-        projectIds,
-        startDate,
-        endDate,
-        model: query.model || query.platform,
-        limit: query.limit,
-      });
-      return ok(ResponseFeedDto.toEnvelopeJSON(result));
+      return ok(envelope);
     } catch (e) {
-      return mapError(e, log, reqCtxOf(ctx));
+      if (e instanceof ElementsTransportError) {
+        const upstreamWorkspaceId = e.workspaceId;
+        e.workspaceId = undefined;
+        e.body = undefined;
+        if (hasText(upstreamWorkspaceId) && typeof e.message === 'string') {
+          e.message = e.message.replaceAll(upstreamWorkspaceId, '[redacted]');
+        }
+        if (typeof e.endpoint === 'string') {
+          e.endpoint = e.endpoint.replace(
+            /\/workspaces\/[^/]+/,
+            '/workspaces/[redacted]',
+          );
+        }
+      }
+      return mapError(e, log, brandClaimsReqCtx(ctx));
     }
   };
 

--- a/src/dto/response-feed.js
+++ b/src/dto/response-feed.js
@@ -10,79 +10,22 @@
  * governing permissions and limitations under the License.
  */
 
-/**
- * DTO for the Brand Claims response feed.
- *
- * Shapes the joined `(answer + its cited sources)` records into the API contract. The
- * upstream Semrush element rows are never exposed: `execution_id` (an opaque composite of
- * the join tuple), `model_name_cbf_value`, and the raw `tags` blob all stay server-side.
- */
-
-/**
- * Maps one joined source row to its API form.
- *
- * ⚠️ `position` is the element's AGGREGATE ranking for that domain, NOT the position the
- * citation occupied inline in the answer text. The array is ordered by it because that
- * yields a stable, sensible sequence — but this is explicitly NOT a claim about inline
- * citation order, which Semrush does not expose today. Consumers must not present it as
- * "the order the model cited these".
- *
- * @param {object} source - Joined source row.
- * @returns {object} API representation.
- */
-const toSourceJSON = (source) => ({
-  url: source.url ?? '',
-  domain: source.source ?? '',
-  rank: source.position ?? 0,
-  domainType: source.domainType ?? '',
-});
-
+/** Public DTO for one page of combined Brand Claims executions. */
 export const ResponseFeedDto = {
-  /**
-   * Maps one joined record to its API form.
-   *
-   * `model` and `date` are exposed EXPLICITLY and are not optional. The downstream Brand
-   * Claims consumer keys its own identity on `(prompt, region)` — it carries no model and
-   * no date dimension — so it cannot reconstruct either from anything else in the payload.
-   * Dropping them here would silently collapse distinct executions into one.
-   *
-   * @param {object} record - Record from `joinResponsesToSources`.
-   * @returns {object} camelCase API representation.
-   */
-  toJSON: (record) => ({
-    projectId: record.projectId ?? '',
-    prompt: record.prompt ?? '',
-    // Load-bearing for the consumer — see above.
-    model: record.model ?? '',
-    date: record.date ?? '',
-    response: record.response ?? '',
-    // Empty when that execution cited nothing. ABSENCE IS MEANINGFUL: an empty array means
-    // "this model cited no sources on this day", never "sources were lost".
-    sources: (record.sources ?? []).map(toSourceJSON),
-    sourceCount: record.sourceRowCount ?? 0,
+  toJSON: (row) => ({
+    projectId: row.projectId,
+    prompt: row.prompt,
+    response: row.response,
+    date: row.date,
+    model: row.model,
+    responses: row.responses,
+    sources: [...row.sources],
+    tags: [...row.tags],
   }),
 
-  /**
-   * Wraps the feed in its response envelope.
-   *
-   * `truncated` and `unmatchedSourceKeyCount` exist so a consumer can tell an incomplete
-   * read from a genuinely quiet day — the distinction the whole feed depends on, since a
-   * missing tuple is normally legitimate (a model runs on a median 61 of 74 days).
-   *
-   * @param {object} feed - Result from `getResponseFeed`.
-   * @returns {object} API response body.
-   */
-  toEnvelopeJSON: (feed) => ({
-    records: (feed.records ?? []).map(ResponseFeedDto.toJSON),
-    totalCount: (feed.records ?? []).length,
-    days: feed.days ?? [],
-    projectIds: feed.projectIds ?? [],
-    pageSize: feed.pageSize ?? 0,
-    // True when at least one upstream page came back full, so this window may be clipped.
-    // A consumer seeing this should narrow the range rather than treat the result as whole.
-    truncated: feed.truncated ?? false,
-    // Source rows whose answer was not in the same page. Normally 0; a persistently high
-    // value means the two elements disagreed and the join is losing citations.
-    unmatchedSourceKeyCount: feed.unmatchedSourceKeyCount ?? 0,
+  toEnvelopeJSON: ({ data, page, slice }) => ({
+    data: data.map(ResponseFeedDto.toJSON),
+    page: { ...page },
+    slice: { ...slice },
   }),
 };

--- a/src/support/elements/definitions/brand-claims-responses.js
+++ b/src/support/elements/definitions/brand-claims-responses.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ElementsTransportError } from '../errors.js';
+import { buildAdvancedFilters } from '../constants.js';
+
+export const DEFAULT_BRAND_CLAIMS_PAGE_SIZE = 500;
+export const MAX_BRAND_CLAIMS_PAGE_SIZE = 500;
+export const BRAND_CLAIMS_MODEL = 'search-gpt';
+
+const SORT_COLUMNS = Object.freeze([
+  'project_id asc',
+  'prompt asc',
+  'model asc',
+  'date asc',
+]);
+
+function invalidResponse(path) {
+  return new ElementsTransportError(
+    502,
+    `Malformed Brand Claims Elements response at ${path}`,
+  );
+}
+
+/**
+ * Builds the verified one-project, one-Monday request for combined Brand Claims element
+ * 55e89619. The transport owns the single external `render_data` wrapper.
+ */
+export function buildBrandClaimsResponsesPayload({
+  projectId,
+  date,
+  pageSize = DEFAULT_BRAND_CLAIMS_PAGE_SIZE,
+  offset = 0,
+} = {}) {
+  return {
+    project_id: projectId,
+    statistics: { rowCount: { col: '*', func: 'count' } },
+    filters: {
+      simple: {
+        CBF_date__start: date,
+        CBF_date__end: date,
+      },
+      ...buildAdvancedFilters([
+        { op: 'or', filters: [{ op: 'eq', val: BRAND_CLAIMS_MODEL, col: 'CBF_model' }] },
+        { op: 'gte', val: date, col: 'CBF_date__start' },
+        { op: 'lte', val: date, col: 'CBF_date__end' },
+      ]),
+    },
+    pagination: {
+      limit: pageSize,
+      offset,
+      sort_columns: [...SORT_COLUMNS],
+    },
+  };
+}
+
+function requiredText(row, field, index, { allowWhitespace = false } = {}) {
+  if (typeof row[field] !== 'string' || (!allowWhitespace && row[field].trim() === '')) {
+    throw invalidResponse(`blocks.data[${index}].${field}`);
+  }
+  return row[field];
+}
+
+function stringArray(row, field, index) {
+  if (!Array.isArray(row[field]) || row[field].some((value) => typeof value !== 'string')) {
+    throw invalidResponse(`blocks.data[${index}].${field}`);
+  }
+  return [...row[field]];
+}
+
+/**
+ * Strictly normalizes the combined element response. Missing fields and wrong types are
+ * upstream schema drift, not an empty corpus. Raw customer data is never attached to errors.
+ */
+export function transformBrandClaimsResponsesResponse(raw) {
+  if (!raw?.blocks || !Array.isArray(raw.blocks.data)) {
+    throw invalidResponse('blocks.data');
+  }
+  const statistics = raw.blocks.data_statistics;
+  if (!Array.isArray(statistics) || statistics.length !== 1) {
+    throw invalidResponse('blocks.data_statistics');
+  }
+  const rowCount = statistics[0]?.rowCount;
+  if (!Number.isInteger(rowCount) || rowCount < 0) {
+    throw invalidResponse('blocks.data_statistics[0].rowCount');
+  }
+
+  const data = raw.blocks.data.map((row, index) => {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+      throw invalidResponse(`blocks.data[${index}]`);
+    }
+    if (!Number.isInteger(row.responses) || row.responses < 0) {
+      throw invalidResponse(`blocks.data[${index}].responses`);
+    }
+    return {
+      projectId: requiredText(row, 'project_id', index),
+      prompt: requiredText(row, 'prompt', index),
+      response: requiredText(row, 'response', index),
+      date: requiredText(row, 'date', index),
+      model: requiredText(row, 'model', index),
+      responses: row.responses,
+      sources: stringArray(row, 'sources', index),
+      tags: stringArray(row, 'tags', index),
+    };
+  });
+
+  return { data, rowCount };
+}

--- a/src/support/elements/definitions/brand-claims-responses.js
+++ b/src/support/elements/definitions/brand-claims-responses.js
@@ -77,6 +77,17 @@ function stringArray(row, field, index) {
   return [...row[field]];
 }
 
+function executionDate(row, index) {
+  const value = requiredText(row, 'date', index);
+  // Live 55e89619 rows use UTC-midnight timestamps while the public contract and request use
+  // YYYY-MM-DD. Accept only those equivalent wire shapes and normalize to the requested form.
+  const match = /^(\d{4}-\d{2}-\d{2})(?:T00:00:00(?:\.000)?Z)?$/.exec(value);
+  if (!match || new Date(`${match[1]}T00:00:00Z`).toISOString().slice(0, 10) !== match[1]) {
+    throw invalidResponse(`blocks.data[${index}].date`);
+  }
+  return match[1];
+}
+
 /**
  * Strictly normalizes the combined element response. Missing fields and wrong types are
  * upstream schema drift, not an empty corpus. Raw customer data is never attached to errors.
@@ -105,7 +116,7 @@ export function transformBrandClaimsResponsesResponse(raw) {
       projectId: requiredText(row, 'project_id', index),
       prompt: requiredText(row, 'prompt', index),
       response: requiredText(row, 'response', index),
-      date: requiredText(row, 'date', index),
+      date: executionDate(row, index),
       model: requiredText(row, 'model', index),
       responses: row.responses,
       sources: stringArray(row, 'sources', index),

--- a/src/support/elements/definitions/index.js
+++ b/src/support/elements/definitions/index.js
@@ -44,6 +44,13 @@ export {
   buildResponseSourcesPayload, transformResponseSourcesResponse,
 } from './response-sources.js';
 export { joinResponsesToSources, diffDayExecutions } from './response-feed.js';
+export {
+  buildBrandClaimsResponsesPayload,
+  transformBrandClaimsResponsesResponse,
+  DEFAULT_BRAND_CLAIMS_PAGE_SIZE,
+  MAX_BRAND_CLAIMS_PAGE_SIZE,
+  BRAND_CLAIMS_MODEL,
+} from './brand-claims-responses.js';
 export { buildSubredditsPayload, transformSubredditsResponse } from './subreddits.js';
 export { buildRedditThreadsPayload, transformRedditThreadsResponse } from './reddit-threads.js';
 export { buildYoutubeVideosPayload, transformYoutubeVideosResponse } from './youtube-videos.js';

--- a/src/support/elements/element-ids.js
+++ b/src/support/elements/element-ids.js
@@ -137,6 +137,10 @@ export const ELEMENT_IDS = Object.freeze({
   SOURCES: '553cd819-d507-460d-a8ff-e34486bad3e1',
   SOURCES_DATES: '404fb017-7e44-41ec-896f-7138f731da60',
 
+  // Combined Brand Claims execution feed: one row includes prompt, response, date, model,
+  // per-execution sources, response count, and tags.
+  BRAND_CLAIMS_RESPONSES: '55e89619-4b02-4319-be91-590e58da8815',
+
   // Prompt Details
   PROMPT_AI_ANSWERS: '45d6251f-15cd-4b33-a7f6-de97925e900e',
   PROMPT_SOURCES: '7db0df5c-6679-4495-8ea8-ef2dfd7e5251',

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -12,9 +12,10 @@
 
 import { hasText } from '@adobe/spacecat-shared-utils';
 import { ELEMENT_IDS } from './element-ids.js';
+import { ElementsTransportError } from './errors.js';
 import { SEP } from './constants.js';
 import { mapWithConcurrency } from './concurrency.js';
-import { splitDateRangeIntoWeeksBackward, addDaysToDate } from './week-utils.js';
+import { splitDateRangeIntoWeeksBackward } from './week-utils.js';
 import {
   DIMENSION,
   INTENT_VALUE,
@@ -41,13 +42,9 @@ import {
   buildCitedDomainsPayload,
   transformCitedDomainsResponse,
   transformCitedDomainsResponses,
-  buildPromptResponsesPayload,
-  transformPromptResponsesResponse,
-  clampLimit,
-  buildResponseSourcesPayload,
-  transformResponseSourcesResponse,
-  joinResponsesToSources,
-  diffDayExecutions,
+  buildBrandClaimsResponsesPayload,
+  transformBrandClaimsResponsesResponse,
+  DEFAULT_BRAND_CLAIMS_PAGE_SIZE,
   buildSubredditsPayload,
   transformSubredditsResponse,
   buildRedditThreadsPayload,
@@ -100,45 +97,7 @@ const SOURCE_VISIBILITY_CALL_MAX_RETRIES = 1;
 // TRENDS_MAX_WEEKS=8 weeks x 4 element calls each) so a wide date range can't
 // spawn an unbounded number of parallel Semrush requests.
 const STATS_TRENDS_WEEK_CONCURRENCY = 4;
-
-/**
- * Bounds parallel per-project (per-market) fan-out for the response feed.
- *
- * Deliberately lower than {@link FANOUT_CONCURRENCY} elsewhere in this file. The production
- * path for this feed is the technical account over the external gateway, whose rate limit is
- * 100 requests per ~60s window and is PER CREDENTIAL, not per workspace (measured
- * 2026-09-04: three different workspaces decremented one shared counter under one reset
- * timestamp). The budget therefore does NOT scale with the number of brands — every
- * consumer of that credential draws from one pool, so this feed contends fleet-wide and a
- * large multi-market brand must not be able to spend the budget in a burst.
- *
- * The internal IMS route exposes no `x-ratelimit-*` headers, but that is absence of
- * evidence, not a higher limit — the bound above is the one to design against.
- *
- * Each unit of concurrency costs 2 requests per boundary (one per element), so 4 markets
- * over a 7-day range is already 4 x 8 x 2 = 64 requests against a 100-per-minute pool.
- */
-const RESPONSE_FEED_CONCURRENCY = 4;
-
-/**
- * Expands an inclusive `YYYY-MM-DD` range into its individual days, oldest first.
- *
- * The controller has already validated both ends and capped the span, so this does no
- * validation of its own beyond guarding against a non-terminating loop.
- *
- * @param {string} startDate - First day, `YYYY-MM-DD`.
- * @param {string} endDate - Last day, `YYYY-MM-DD`.
- * @returns {string[]} Days from `startDate` to `endDate` inclusive.
- */
-function enumerateDays(startDate, endDate) {
-  const days = [];
-  let cursor = startDate;
-  while (cursor <= endDate) {
-    days.push(cursor);
-    cursor = addDaysToDate(cursor, 1);
-  }
-  return days;
-}
+const BRAND_CLAIMS_UPSTREAM_MAX_BYTES = 8 * 1024 * 1024;
 
 /**
  * Creates the Elements service that composes transport calls with per-element
@@ -337,143 +296,61 @@ export function createElementsService(transport, log) {
     },
 
     /**
-     * Fetches the Brand Claims RESPONSE FEED for a date range: each AI answer paired with
-     * the sources cited in that same execution.
+     * Fetches one page of one owned market's Brand Claims executions for one Monday.
+     * The controller resolves ownership; this layer makes exactly one combined-element call,
+     * validates the returned slice, and derives pagination from explicit upstream rowCount.
      *
-     * Neither element can serve this alone. `CITATIONS_SOURCES` (141adc88) has the answer
-     * text but NO date; `SOURCES_DATES` (404fb017) has the date and the cited URLs but no
-     * answer. They are joined on `(project_id, prompt, model, date)` — sound because at most
-     * one execution exists per that tuple (measured 2026-09-04: 2,553 tuples, every one
-     * mapping to exactly one `execution_id`, zero violations).
-     *
-     * BOUNDARY AMORTISATION — the reason this is range-based rather than per-day. The
-     * element ignores `CBF_date__start` and honours `CBF_date__end` as an upper bound over a
-     * rolling window, so a single day is recovered as a difference of two pulls:
-     *
-     *     executions(D) = responses(end = D) MINUS responses(end = D-1)
-     *
-     * Consecutive days SHARE a boundary, so fetching each boundary exactly once and reusing
-     * it for the two days it borders costs N+1 pulls for N days rather than 2N — a ~43%
-     * saving at a week, approaching 2x for longer ranges. The boundary set below is built
-     * once and indexed; no day re-fetches a boundary its neighbour already pulled.
-     *
-     * BUDGET. The production path for this feed is the technical account over the external
-     * gateway, where the rate limit is 100 requests per ~60s window and is PER CREDENTIAL,
-     * not per workspace (measured 2026-09-04: three different workspaces decremented one
-     * shared counter under one reset timestamp). The budget does NOT scale with brands, so
-     * this endpoint contends fleet-wide with every other consumer of that credential. Hence
-     * the deliberately low {@link RESPONSE_FEED_CONCURRENCY}, no retry logic here (a retry
-     * storm would consume the shared pool), and a preference for fewer/larger pages: every
-     * call re-scans the whole rolling window, so raising `limit` is strictly better than
-     * walking `offset`. The internal IMS route publishes no rate-limit headers, which is
-     * absence of evidence rather than a higher ceiling.
-     *
-     * ABSENCE IS MEANINGFUL. A `(prompt, model)` tuple runs on a median 61 of 74 days
-     * (`google-ai-overview` on only 50), so gaps are ROUTINE. A missing tuple means that
-     * model did not run that day — never an error, never data loss. No branch here treats an
-     * empty page or an unmatched key as a failure.
-     *
-     * @param {string} workspaceId - Semrush workspace UUID (resolved from the brand; the
-     *   caller never supplies one).
-     * @param {object} params - Query params.
-     * @param {string[]} [params.projectIds] - Ownership-checked project ids (one per
-     *   market). Empty → a single workspace-wide call.
-     * @param {string} params.startDate - First day to report, `YYYY-MM-DD`.
-     * @param {string} params.endDate - Last day to report, `YYYY-MM-DD`.
-     * @param {string} [params.model] - Model/platform filter.
-     * @param {number} [params.limit] - Upstream page size (clamped by the payload builders).
-     * @returns {Promise<object>} `{ records, days, projectIds, pageSize, truncated,
-     *   unmatchedSourceKeyCount }`.
+     * @param {string} workspaceId - Server-resolved Semrush sub-workspace UUID.
+     * @param {object} params
+     * @param {string} params.projectId - Server-resolved Semrush project UUID.
+     * @param {string} params.date - Exact selected Monday (YYYY-MM-DD).
+     * @param {number} params.offset - Non-negative row offset.
+     * @param {number} params.pageSize - Page size in 1..500.
+     * @returns {Promise<{data: object[], page: object}>}
      */
-    async getResponseFeed(workspaceId, params) {
-      const {
-        projectIds, startDate, endDate, model, limit,
-      } = params;
-      const ids = Array.isArray(projectIds)
-        // `.trim()` before the emptiness test: `hasText('  ')` is true, so a whitespace-only
-        // id would otherwise become a scope and be sent upstream as `project_id: '  '`.
-        // The controller's UUID validation makes that unreachable today, but the service
-        // must not depend on a caller-side check for its own correctness.
-        ? [...new Set(projectIds.map((id) => String(id ?? '').trim()).filter(hasText))]
-        : [];
-      // No project id → one workspace-wide read. `undefined` (not '') so the payload
-      // builders omit `project_id` entirely rather than sending an empty scope.
-      const scopes = ids.length > 0 ? ids : [undefined];
-
-      // Days to report, plus the extra D-1 boundary the first day needs. Each boundary is
-      // fetched ONCE below and reused by the (at most two) days that border it.
-      const days = enumerateDays(startDate, endDate);
-      const boundaries = [addDaysToDate(days[0], -1), ...days];
-
-      const perScope = await mapWithConcurrency(
-        scopes,
-        RESPONSE_FEED_CONCURRENCY,
-        async (projectId) => {
-          const answersByBoundary = new Map();
-          const sourcesByBoundary = new Map();
-          // Sequential across boundaries: the credential's budget is shared fleet-wide, so
-          // this trades wall-clock for a smaller instantaneous burst against the 100/min pool.
-          for (const boundary of boundaries) {
-            /* eslint-disable no-await-in-loop */
-            const [rawAnswers, rawSources] = await Promise.all([
-              transport.fetchElement(
-                workspaceId,
-                ELEMENT_IDS.CITATIONS_SOURCES,
-                buildPromptResponsesPayload({
-                  projectId, model, endDate: boundary, limit,
-                }),
-              ),
-              transport.fetchElement(
-                workspaceId,
-                ELEMENT_IDS.SOURCES_DATES,
-                buildResponseSourcesPayload({
-                  projectId, model, endDate: boundary, limit,
-                }),
-              ),
-            ]);
-            /* eslint-enable no-await-in-loop */
-            answersByBoundary.set(boundary, transformPromptResponsesResponse(rawAnswers));
-            sourcesByBoundary.set(boundary, transformResponseSourcesResponse(rawSources));
-          }
-          return { answersByBoundary, sourcesByBoundary };
+    async getResponseFeed(workspaceId, {
+      projectId,
+      date,
+      offset = 0,
+      pageSize = DEFAULT_BRAND_CLAIMS_PAGE_SIZE,
+      maxUpstreamBytes = BRAND_CLAIMS_UPSTREAM_MAX_BYTES,
+    }) {
+      const raw = await transport.fetchElement(
+        workspaceId,
+        ELEMENT_IDS.BRAND_CLAIMS_RESPONSES,
+        buildBrandClaimsResponsesPayload({
+          projectId, date, offset, pageSize,
+        }),
+        {
+          maxResponseBytes: maxUpstreamBytes,
+          redactWorkspaceInErrors: true,
         },
       );
+      const { data, rowCount } = transformBrandClaimsResponsesResponse(raw);
+      const returned = data.length;
 
-      const records = [];
-      let unmatchedSourceKeyCount = 0;
-      let truncated = false;
-      const pageSize = clampLimit(limit);
-
-      for (const { answersByBoundary, sourcesByBoundary } of perScope) {
-        for (const day of days) {
-          // Every `day` and its `D-1` predecessor are members of `boundaries`, which was
-          // fully populated above — so these lookups always hit. No `?? []` fallback: it
-          // would be unreachable, and would mask a genuine gap if the boundary set and the
-          // day list ever fell out of step.
-          const answersToday = answersByBoundary.get(day);
-          const answersYesterday = answersByBoundary.get(addDaysToDate(day, -1));
-          // A full page means the upstream window was cut off, so this day's difference may
-          // be incomplete. Reported rather than silently served as if it were whole.
-          if (answersToday.length >= pageSize) {
-            truncated = true;
-          }
-          const dayAnswers = diffDayExecutions(answersToday, answersYesterday);
-          // Source rows carry their own date, so the day's rows are selected directly
-          // rather than by difference — no second pull needed on this side.
-          const daySources = sourcesByBoundary.get(day).filter((row) => row.date === day);
-          const joined = joinResponsesToSources(dayAnswers, daySources, { date: day });
-          records.push(...joined.records);
-          unmatchedSourceKeyCount += joined.unmatchedSourceKeys.length;
+      if (returned > pageSize || offset + returned > rowCount) {
+        throw new ElementsTransportError(502, 'Malformed Brand Claims pagination metadata');
+      }
+      if (returned === 0 && rowCount > 0) {
+        throw new ElementsTransportError(502, 'Brand Claims returned an empty nonterminal page');
+      }
+      for (const row of data) {
+        if (row.projectId !== projectId || row.date !== date || row.model !== 'search-gpt') {
+          throw new ElementsTransportError(502, 'Brand Claims row is outside the requested slice');
         }
       }
 
+      const consumed = offset + returned;
       return {
-        records,
-        days,
-        projectIds: ids,
-        pageSize,
-        truncated,
-        unmatchedSourceKeyCount,
+        data,
+        page: {
+          offset,
+          pageSize,
+          returned,
+          rowCount,
+          nextOffset: consumed < rowCount ? consumed : null,
+        },
       };
     },
     /**

--- a/src/support/elements/elements-service.js
+++ b/src/support/elements/elements-service.js
@@ -98,6 +98,13 @@ const SOURCE_VISIBILITY_CALL_MAX_RETRIES = 1;
 // spawn an unbounded number of parallel Semrush requests.
 const STATS_TRENDS_WEEK_CONCURRENCY = 4;
 const BRAND_CLAIMS_UPSTREAM_MAX_BYTES = 8 * 1024 * 1024;
+// One-model/500-row live probes completed in 4.6-7.3s under concurrency 4; the prior measured
+// maximum was 10.9s. A 20s end-to-end upstream budget leaves material headroom while still
+// expiring before API Gateway's ~29-30s integration ceiling. Disable transport-level 429 retries
+// for this synchronous route: a retry plus Retry-After can outlive the client request, and Mystique
+// retries the failed page as a separate bounded request.
+const BRAND_CLAIMS_TIMEOUT_MS = 20_000;
+const BRAND_CLAIMS_MAX_RETRIES = 0;
 
 /**
  * Creates the Elements service that composes transport calls with per-element
@@ -322,6 +329,8 @@ export function createElementsService(transport, log) {
           projectId, date, offset, pageSize,
         }),
         {
+          timeoutMs: BRAND_CLAIMS_TIMEOUT_MS,
+          maxRetries: BRAND_CLAIMS_MAX_RETRIES,
           maxResponseBytes: maxUpstreamBytes,
           redactWorkspaceInErrors: true,
         },

--- a/src/support/elements/elements-transport.js
+++ b/src/support/elements/elements-transport.js
@@ -114,8 +114,66 @@ function buildS2SHeaders(apiKey) {
   };
 }
 
-async function parseBody(response) {
+async function readBoundedText(response, maxResponseBytes, requestInfo) {
+  const limit = Number.isSafeInteger(maxResponseBytes) && maxResponseBytes > 0
+    ? maxResponseBytes
+    : undefined;
+  const contentLength = Number(response.headers?.get('content-length'));
+  if (limit && Number.isFinite(contentLength) && contentLength > limit) {
+    throw new ElementsTransportError(
+      502,
+      `Elements API response exceeds configured ${limit}-byte limit`,
+      undefined,
+      requestInfo(),
+    );
+  }
+
+  if (limit && response.body?.getReader) {
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+    while (true) {
+      // eslint-disable-next-line no-await-in-loop
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      total += value.byteLength;
+      if (total > limit) {
+        // eslint-disable-next-line no-await-in-loop
+        await reader.cancel();
+        throw new ElementsTransportError(
+          502,
+          `Elements API response exceeds configured ${limit}-byte limit`,
+          undefined,
+          requestInfo(),
+        );
+      }
+      chunks.push(value);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    chunks.forEach((chunk) => {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    });
+    return new TextDecoder().decode(bytes);
+  }
+
   const text = await response.text();
+  if (limit && new TextEncoder().encode(text).byteLength > limit) {
+    throw new ElementsTransportError(
+      502,
+      `Elements API response exceeds configured ${limit}-byte limit`,
+      undefined,
+      requestInfo(),
+    );
+  }
+  return text;
+}
+
+async function parseBody(response, maxResponseBytes, requestInfo) {
+  const text = await readBoundedText(response, maxResponseBytes, requestInfo);
   if (!text) {
     return null;
   }
@@ -202,6 +260,8 @@ function nextRetryDelayMs(completedAttempt, baseDelayMs, response) {
  * @param {string} [opts.workspaceId] id of the workspace being called, carried onto the thrown
  *   error's request descriptor for the structured upstream-error log line (SITES-49993)
  * @param {string} [opts.elementId] id of the element being called, ditto
+ * @param {number} [opts.maxResponseBytes] maximum decompressed upstream response bytes
+ * @param {boolean} [opts.redactWorkspaceInErrors] omit workspace identifiers from errors
  * @returns {Promise<*>} parsed response body on success
  */
 async function request(url, headers, body, {
@@ -210,14 +270,22 @@ async function request(url, headers, body, {
   retryBaseDelayMs = DEFAULT_RETRY_BASE_DELAY_MS,
   workspaceId = undefined,
   elementId = undefined,
+  maxResponseBytes = undefined,
+  redactWorkspaceInErrors = false,
 } = {}) {
   const jsonBody = JSON.stringify(body);
   // Floor at 0: a negative/zero maxRetries degrades to a single attempt (no retry).
   const retries = Math.max(0, maxRetries);
+  const errorUrl = redactWorkspaceInErrors
+    ? url.replace(/\/workspaces\/[^/]+/, '/workspaces/[redacted]')
+    : url;
   // Structured request descriptor for the upstream-error log line (SITES-49993).
   // Built only when a throw actually happens — never on the happy path.
   const requestInfo = () => ({
-    method: 'POST', endpoint: endpointOf(url), workspaceId, elementId,
+    method: 'POST',
+    endpoint: endpointOf(errorUrl),
+    workspaceId: redactWorkspaceInErrors ? undefined : workspaceId,
+    elementId,
   });
 
   for (let attempt = 0; ; attempt += 1) {
@@ -234,7 +302,7 @@ async function request(url, headers, body, {
       });
     } catch (e) {
       if (e?.name === 'AbortError') {
-        throw new ElementsTransportError(504, `Elements API POST ${url} timed out after ${timeoutMs}ms`, undefined, requestInfo());
+        throw new ElementsTransportError(504, `Elements API POST ${errorUrl} timed out after ${timeoutMs}ms`, undefined, requestInfo());
       }
       throw e;
     } finally {
@@ -242,7 +310,7 @@ async function request(url, headers, body, {
     }
 
     // eslint-disable-next-line no-await-in-loop
-    const parsed = await parseBody(response);
+    const parsed = await parseBody(response, maxResponseBytes, requestInfo);
     if (response.ok) {
       return parsed;
     }
@@ -255,7 +323,7 @@ async function request(url, headers, body, {
     } else {
       throw new ElementsTransportError(
         response.status,
-        `Elements API POST ${url} failed: ${response.status}`,
+        `Elements API POST ${errorUrl} failed: ${response.status}`,
         parsed,
         requestInfo(),
       );
@@ -321,6 +389,8 @@ export function createElementsTransport({
      *   general-purpose defaults. Omit for the normal single-call case.
      * @param {number} [callOpts.timeoutMs]
      * @param {number} [callOpts.maxRetries]
+     * @param {number} [callOpts.maxResponseBytes]
+     * @param {boolean} [callOpts.redactWorkspaceInErrors]
      */
     async fetchElement(workspaceId, elementId, payload, callOpts = {}) {
       const url = isS2SConsumer
@@ -336,6 +406,8 @@ export function createElementsTransport({
         timeoutMs: callOpts.timeoutMs,
         workspaceId,
         elementId,
+        maxResponseBytes: callOpts.maxResponseBytes,
+        redactWorkspaceInErrors: callOpts.redactWorkspaceInErrors,
       });
     },
   };

--- a/src/support/elements/elements-transport.js
+++ b/src/support/elements/elements-transport.js
@@ -120,6 +120,11 @@ async function readBoundedText(response, maxResponseBytes, requestInfo) {
     : undefined;
   const contentLength = Number(response.headers?.get('content-length'));
   if (limit && Number.isFinite(contentLength) && contentLength > limit) {
+    try {
+      await response.body?.cancel?.();
+    } catch {
+      // Preserve the deterministic typed size error even if Undici cannot cancel the stream.
+    }
     throw new ElementsTransportError(
       502,
       `Elements API response exceeds configured ${limit}-byte limit`,
@@ -140,8 +145,12 @@ async function readBoundedText(response, maxResponseBytes, requestInfo) {
       }
       total += value.byteLength;
       if (total > limit) {
-        // eslint-disable-next-line no-await-in-loop
-        await reader.cancel();
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await reader.cancel();
+        } catch {
+          // Preserve the deterministic typed size error if stream cancellation fails.
+        }
         throw new ElementsTransportError(
           502,
           `Elements API response exceeds configured ${limit}-byte limit`,
@@ -292,6 +301,7 @@ async function request(url, headers, body, {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     let response;
+    let parsed;
     try {
       // eslint-disable-next-line no-await-in-loop
       response = await fetch(url, {
@@ -300,6 +310,11 @@ async function request(url, headers, body, {
         signal: controller.signal,
         body: jsonBody,
       });
+      // Keep the same abort budget active while consuming/decompressing the body. Fetch resolves
+      // when response headers arrive, so clearing the timer before this read would leave a stalled
+      // or slow body unbounded even though callers supplied timeoutMs.
+      // eslint-disable-next-line no-await-in-loop
+      parsed = await parseBody(response, maxResponseBytes, requestInfo);
     } catch (e) {
       if (e?.name === 'AbortError') {
         throw new ElementsTransportError(504, `Elements API POST ${errorUrl} timed out after ${timeoutMs}ms`, undefined, requestInfo());
@@ -309,8 +324,6 @@ async function request(url, headers, body, {
       clearTimeout(timer);
     }
 
-    // eslint-disable-next-line no-await-in-loop
-    const parsed = await parseBody(response, maxResponseBytes, requestInfo);
     if (response.ok) {
       return parsed;
     }

--- a/test/controllers/elements.test.js
+++ b/test/controllers/elements.test.js
@@ -127,6 +127,7 @@ function makeBrandSemrushProject(overrides = {}) {
     getSemrushProjectId: () => 'proj-1',
     getGeoTargetId: () => 2840,
     getLanguageCode: () => 'en',
+    getDeletedAt: () => null,
     ...overrides,
   };
 }
@@ -2245,230 +2246,187 @@ describe('ElementsController', () => {
 
   // ─── extractQuery edge cases ──────────────────────────────────────────────
 
-  // ─── listResponseFeed (Brand Claims response feed) ─────────────────────────
+  // ─── listResponseFeed (Brand Claims synchronous page) ─────────────────────
 
   describe('listResponseFeed', () => {
     const FEED_RESULT = {
-      records: [{
-        projectId: 'proj-1',
+      data: [{
+        projectId: PROJECT_ID_A,
         prompt: 'best running shoes',
-        model: 'chatgpt-paid',
-        date: '2026-08-24',
         response: 'Some answer',
+        date: '2026-09-07',
+        model: 'search-gpt',
+        responses: 1,
         sources: [],
-        sourceRowCount: 0,
+        tags: [],
       }],
-      days: ['2026-08-24'],
-      projectIds: ['proj-1'],
-      pageSize: 5000,
-      truncated: false,
-      unmatchedSourceKeyCount: 0,
+      page: {
+        offset: 0, pageSize: 500, returned: 1, rowCount: 1, nextOffset: null,
+      },
     };
-
     const feedUrl = (qs = '') => `https://api.example.com/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`
       + `/serenity/brand-presence/responses${qs}`;
+    const marketProject = (overrides = {}) => makeBrandSemrushProject({
+      getSemrushProjectId: () => PROJECT_ID_A,
+      getGeoTargetId: () => 2840,
+      getLanguageCode: () => 'en',
+      ...overrides,
+    });
+    const validContext = (overrides = {}) => fakeContext({
+      url: feedUrl('?geoTargetId=2840&languageCode=en&date=2026-09-07'),
+      withBrandSemrushProject: true,
+      brandSemrushProjects: [marketProject()],
+      ...overrides,
+    });
 
     beforeEach(() => {
       serviceStub.getResponseFeed = sinon.stub().resolves(FEED_RESULT);
     });
 
-    it('returns the DTO envelope for a valid range', async () => {
-      const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
+    it('returns one page with the resolved market slice', async () => {
+      const ctx = validContext();
       const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
       expect(res.status).to.equal(200);
-      const body = await readBody(res);
-      expect(body.totalCount).to.equal(1);
-      expect(body.records[0].model).to.equal('chatgpt-paid');
-      expect(body.records[0].date).to.equal('2026-08-24');
-      expect(body.truncated).to.equal(false);
+      expect(await readBody(res)).to.deep.equal({
+        ...FEED_RESULT,
+        slice: {
+          geoTargetId: 2840,
+          languageCode: 'en',
+          date: '2026-09-07',
+          model: 'search-gpt',
+        },
+      });
+      expect(serviceStub.getResponseFeed).to.have.been.calledWith(SUB_WORKSPACE_ID, {
+        projectId: PROJECT_ID_A,
+        date: '2026-09-07',
+        offset: 0,
+        pageSize: 500,
+        maxUpstreamBytes: 8 * 1024 * 1024,
+      });
     });
 
-    it('passes the resolved workspace, never a caller-supplied one', async () => {
-      const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24&workspaceId=evil') });
+    it('passes validated offset and pageSize', async () => {
+      const ctx = validContext({
+        url: feedUrl('?geoTargetId=2840&languageCode=en&date=2026-09-07&offset=500&pageSize=250'),
+      });
       await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-      expect(serviceStub.getResponseFeed).to.have.been.calledWith(SUB_WORKSPACE_ID);
-    });
-
-    describe('date range', () => {
-      it('rejects a malformed from/to', async () => {
-        const ctx = fakeContext({ url: feedUrl('?from=24-08-2026&to=2026-08-24') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-        expect(res.status).to.equal(400);
-      });
-
-      it('rejects an impossible calendar date', async () => {
-        const ctx = fakeContext({ url: feedUrl('?from=2026-13-45&to=2026-08-24') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-        expect(res.status).to.equal(400);
-      });
-
-      it('rejects an inverted range', async () => {
-        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-20') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-        expect(res.status).to.equal(400);
-      });
-
-      // The upstream window is rolling and ~74 days. Beyond it a day is UNRECOVERABLE, and
-      // the upstream returns nothing rather than erroring — which would be served as an
-      // empty result indistinguishable from "no model ran". Rejecting keeps that
-      // ambiguity out of the response.
-      it('rejects a span beyond the rolling window rather than returning an empty result', async () => {
-        const ctx = fakeContext({ url: feedUrl('?from=2026-01-01&to=2026-08-24') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(400);
-        const body = await readBody(res);
-        expect(body.message).to.contain('unrecoverable');
-        expect(serviceStub.getResponseFeed).to.not.have.been.called;
-      });
-
-      it('accepts a span just inside the window', async () => {
-        const ctx = fakeContext({ url: feedUrl('?from=2026-06-13&to=2026-08-24') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-        expect(res.status).to.equal(200);
-      });
-
-      it('accepts the startDate/endDate aliases', async () => {
-        const ctx = fakeContext({ url: feedUrl('?startDate=2026-08-23&endDate=2026-08-24') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(200);
-        expect(serviceStub.getResponseFeed.firstCall.args[1]).to.include({
-          startDate: '2026-08-23', endDate: '2026-08-24',
-        });
-      });
-
-      // Ending yesterday, not today: today's executions are still landing, so ending on
-      // today would report a partial day as if it were complete.
-      it('defaults to the last 7 days ending yesterday', async () => {
-        const ctx = fakeContext({ url: feedUrl() });
-        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        const today = new Date().toISOString().slice(0, 10);
-        const { startDate, endDate } = serviceStub.getResponseFeed.firstCall.args[1];
-        expect(endDate).to.equal(addDaysToDate(today, -1));
-        expect(startDate).to.equal(addDaysToDate(today, -7));
+      expect(serviceStub.getResponseFeed.firstCall.args[1]).to.include({
+        offset: 500,
+        pageSize: 250,
       });
     });
 
-    describe('project ownership (tenant isolation)', () => {
-      // LOAD-BEARING: the technical account is broadly entitled, so a caller who guessed
-      // another brand's Semrush project UUID could otherwise read that tenant's answers.
-      it('forbids a projectId this brand does not own', async () => {
-        const ctx = fakeContext({
-          url: feedUrl('?from=2026-08-24&to=2026-08-24&projectId=11111111-1111-4111-8111-111111111111'),
-          withBrandSemrushProject: true,
-          brandSemrushProjects: brandSemrushProjectsFor(['22222222-2222-4222-8222-222222222222']),
-        });
+    [
+      '?languageCode=en&date=2026-09-07',
+      '?geoTargetId=2840&date=2026-09-07',
+      '?geoTargetId=2840&languageCode=en&date=2026-09-08',
+      '?geoTargetId=2840&languageCode=en&date=bad',
+      '?geoTargetId=2840&languageCode=en&date=2026-09-07&pageSize=501',
+      '?geoTargetId=2840&languageCode=en&date=2026-09-07&offset=-1',
+      '?geoTargetId=2840&languageCode=en&date=2026-09-07&model=perplexity',
+      '?geoTargetId=2840&languageCode=en&date=2026-09-07&workspaceId=evil',
+      `?geoTargetId=2840&languageCode=en&date=2026-09-07&projectId=${PROJECT_ID_B}`,
+    ].forEach((query) => {
+      it(`rejects invalid or authority-expanding query ${query}`, async () => {
+        const ctx = validContext({ url: feedUrl(query) });
         const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(403);
-        expect(serviceStub.getResponseFeed).to.not.have.been.called;
-      });
-
-      it('allows a projectId the brand owns', async () => {
-        const owned = '22222222-2222-4222-8222-222222222222';
-        const ctx = fakeContext({
-          url: feedUrl(`?from=2026-08-24&to=2026-08-24&projectId=${owned}`),
-          withBrandSemrushProject: true,
-          brandSemrushProjects: brandSemrushProjectsFor([owned]),
-        });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(200);
-        expect(serviceStub.getResponseFeed.firstCall.args[1].projectIds).to.deep.equal([owned]);
-      });
-
-      it('rejects a non-UUID projectId before any upstream call', async () => {
-        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24&projectId=not-a-uuid') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
         expect(res.status).to.equal(400);
-        expect(serviceStub.getResponseFeed).to.not.have.been.called;
-      });
-
-      it('scopes to all of the brand markets when no projectId is given', async () => {
-        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
-        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(serviceStub.getResponseFeed.firstCall.args[1].projectIds).to.deep.equal([]);
-      });
-
-      // The ownership check must fail CLOSED when the data-access layer yields no
-      // BrandSemrushProject: the owned set is empty, so any supplied id is unowned and the
-      // request is denied rather than passed upstream unchecked.
-      it('denies a supplied projectId when no brand projects are resolvable', async () => {
-        const ctx = fakeContext({
-          url: feedUrl('?from=2026-08-24&to=2026-08-24&projectId=22222222-2222-4222-8222-222222222222'),
-          withBrandSemrushProject: true,
-          brandSemrushProjects: [],
-        });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(403);
         expect(serviceStub.getResponseFeed).to.not.have.been.called;
       });
     });
 
-    describe('auth guards', () => {
-      it('403s when the caller lacks access to the organization', async () => {
-        accessControlHasAccessStub.resolves(false);
-        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(403);
-        expect(serviceStub.getResponseFeed).to.not.have.been.called;
+    it('returns 404 when the requested market is not owned by the brand', async () => {
+      const ctx = validContext({
+        brandSemrushProjects: [marketProject({ getGeoTargetId: () => 2756 })],
       });
-
-      it('404s when serenity is not active for the brand', async () => {
-        isSerenityActiveForBrandStub.resolves(false);
-        const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(404);
-      });
-
-      it('400s on a malformed brand id', async () => {
-        const ctx = fakeContext({
-          url: feedUrl('?from=2026-08-24&to=2026-08-24'),
-          params: { brandId: 'not-a-uuid' },
-        });
-        const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(res.status).to.equal(400);
-      });
-    });
-
-    describe('query passthrough', () => {
-      it('forwards the model filter and page limit', async () => {
-        const ctx = fakeContext({
-          url: feedUrl('?from=2026-08-24&to=2026-08-24&model=perplexity&limit=100'),
-        });
-        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(serviceStub.getResponseFeed.firstCall.args[1]).to.include({
-          model: 'perplexity', limit: '100',
-        });
-      });
-
-      it('accepts platform as a legacy alias for model', async () => {
-        const ctx = fakeContext({
-          url: feedUrl('?from=2026-08-24&to=2026-08-24&platform=grok'),
-        });
-        await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
-
-        expect(serviceStub.getResponseFeed.firstCall.args[1].model).to.equal('grok');
-      });
-    });
-
-    it('maps an upstream transport failure to 502', async () => {
-      serviceStub.getResponseFeed.rejects(new MockElementsTransportError(500, 'boom'));
-      const ctx = fakeContext({ url: feedUrl('?from=2026-08-24&to=2026-08-24') });
       const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+      expect(res.status).to.equal(404);
+      expect(serviceStub.getResponseFeed).to.not.have.been.called;
+    });
 
+    it('returns 404 without transport for a matching tombstoned market', async () => {
+      const ctx = validContext({
+        brandSemrushProjects: [marketProject({
+          getDeletedAt: () => '2026-09-01T00:00:00.000Z',
+        })],
+      });
+      const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+      expect(res.status).to.equal(404);
+      expect(serviceStub.getResponseFeed).to.not.have.been.called;
+    });
+
+    it('fails closed when data access returns a cross-brand project', async () => {
+      const ctx = validContext({
+        brandSemrushProjects: [marketProject({ getBrandId: () => PROJECT_ID_B })],
+      });
+      const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+      expect(res.status).to.equal(404);
+      expect(serviceStub.getResponseFeed).to.not.have.been.called;
+    });
+
+    it('returns 409 for an ambiguous duplicate market mapping', async () => {
+      const ctx = validContext({ brandSemrushProjects: [marketProject(), marketProject()] });
+      const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+      expect(res.status).to.equal(409);
+      expect(serviceStub.getResponseFeed).to.not.have.been.called;
+    });
+
+    it('requires a brand sub-workspace', async () => {
+      resolveBrandWorkspaceStub.resolves({
+        mode: 'flat', workspaceId: WORKSPACE_ID, parentWorkspaceId: WORKSPACE_ID,
+      });
+      const ctx = validContext();
+      const res = await ElementsController(ctx, fakeLog(), ENV).listResponseFeed(ctx);
+      expect(res.status).to.equal(404);
+      expect(serviceStub.getResponseFeed).to.not.have.been.called;
+    });
+
+    it('accepts an outbound body exactly at the configured byte ceiling', async () => {
+      const envelope = {
+        ...FEED_RESULT,
+        slice: {
+          geoTargetId: 2840,
+          languageCode: 'en',
+          date: '2026-09-07',
+          model: 'search-gpt',
+        },
+      };
+      const limit = new TextEncoder().encode(JSON.stringify(envelope)).byteLength;
+      const ctx = validContext();
+      const res = await ElementsController(ctx, fakeLog(), {
+        ...ENV,
+        BRAND_CLAIMS_MAX_OUTBOUND_BYTES: String(limit),
+      }).listResponseFeed(ctx);
+      expect(res.status).to.equal(200);
+    });
+
+    it('rejects an outbound body above the configured byte ceiling before response emission', async () => {
+      const ctx = validContext();
+      const res = await ElementsController(ctx, fakeLog(), {
+        ...ENV,
+        BRAND_CLAIMS_MAX_OUTBOUND_BYTES: '1',
+      }).listResponseFeed(ctx);
       expect(res.status).to.equal(502);
+    });
+
+    it('redacts brand and workspace identifiers from endpoint error logs', async () => {
+      const error = new MockElementsTransportError(
+        500,
+        `request to workspace ${SUB_WORKSPACE_ID} failed`,
+        { workspaceId: SUB_WORKSPACE_ID },
+      );
+      error.workspaceId = SUB_WORKSPACE_ID;
+      error.endpoint = `/workspaces/${SUB_WORKSPACE_ID}/products/ai/elements/55e89619`;
+      serviceStub.getResponseFeed.rejects(error);
+      const log = fakeLog();
+      const ctx = validContext({ log });
+      const res = await ElementsController(ctx, log, ENV).listResponseFeed(ctx);
+      expect(res.status).to.equal(502);
+      const message = log.error.firstCall.args[0];
+      expect(message).to.not.include(BRAND_ID);
+      expect(message).to.not.include(SUB_WORKSPACE_ID);
+      expect(message).to.include('brandIdHash');
+      expect(message).to.include('/workspaces/[redacted]/');
     });
   });
   describe('extractQuery', () => {

--- a/test/dto/response-feed.test.js
+++ b/test/dto/response-feed.test.js
@@ -13,128 +13,34 @@
 import { expect } from 'chai';
 import { ResponseFeedDto } from '../../src/dto/response-feed.js';
 
-const record = (over = {}) => ({
-  projectId: 'proj-1',
-  prompt: 'best running shoes',
-  model: 'chatgpt-paid',
-  date: '2026-08-24',
-  response: 'Some answer text',
-  tags: '$abv_tags$type__branded',
-  sources: [{
-    url: 'https://runnersworld.com/best',
-    source: 'runnersworld.com',
-    position: 1,
-    domainType: 'Earned',
-  }],
-  sourceRowCount: 1,
-  ...over,
-});
+const row = {
+  projectId: 'project-1',
+  prompt: 'Which shoes are best?',
+  response: 'A complete answer',
+  date: '2026-09-07',
+  model: 'search-gpt',
+  responses: 1,
+  sources: ['https://example.com/b', 'https://example.com/a'],
+  tags: ['$abv_tags$intent__commercial'],
+};
 
 describe('ResponseFeedDto', () => {
-  describe('toJSON', () => {
-    it('maps a joined record onto the API contract', () => {
-      expect(ResponseFeedDto.toJSON(record())).to.deep.equal({
-        projectId: 'proj-1',
-        prompt: 'best running shoes',
-        model: 'chatgpt-paid',
-        date: '2026-08-24',
-        response: 'Some answer text',
-        sources: [{
-          url: 'https://runnersworld.com/best',
-          domain: 'runnersworld.com',
-          rank: 1,
-          domainType: 'Earned',
-        }],
-        sourceCount: 1,
-      });
-    });
-
-    // The downstream consumer keys on (prompt, region) and carries no model or date
-    // dimension, so it cannot reconstruct either. Dropping them would silently collapse
-    // distinct executions into one.
-    it('always exposes model and date, which the consumer cannot reconstruct', () => {
-      const json = ResponseFeedDto.toJSON(record());
-      expect(json).to.have.property('model', 'chatgpt-paid');
-      expect(json).to.have.property('date', '2026-08-24');
-    });
-
-    it('never leaks upstream-only fields', () => {
-      const json = ResponseFeedDto.toJSON(record({
-        executionId: 'proj-1|2026-08-24|chatgpt-paid|best running shoes',
-        modelNameCbfValue: 'ChatGPT (paid)',
-      }));
-      expect(json).to.not.have.property('executionId');
-      expect(json).to.not.have.property('modelNameCbfValue');
-      expect(json).to.not.have.property('tags');
-    });
-
-    // Empty sources mean "cited nothing that day", which is routine and not an error.
-    it('renders an empty source list rather than omitting the field', () => {
-      const json = ResponseFeedDto.toJSON(record({ sources: [], sourceRowCount: 0 }));
-      expect(json.sources).to.deep.equal([]);
-      expect(json.sourceCount).to.equal(0);
-    });
-
-    it('defaults every field on a sparse record instead of emitting undefined', () => {
-      expect(ResponseFeedDto.toJSON({})).to.deep.equal({
-        projectId: '',
-        prompt: '',
-        model: '',
-        date: '',
-        response: '',
-        sources: [],
-        sourceCount: 0,
-      });
-    });
-
-    it('defaults missing fields on a sparse source row', () => {
-      const json = ResponseFeedDto.toJSON(record({ sources: [{}] }));
-      expect(json.sources[0]).to.deep.equal({
-        url: '', domain: '', rank: 0, domainType: '',
-      });
-    });
+  it('preserves the frozen normalized row, including source order', () => {
+    expect(ResponseFeedDto.toJSON(row)).to.deep.equal(row);
   });
 
-  describe('toEnvelopeJSON', () => {
-    it('wraps the records with the paging and integrity envelope', () => {
-      const envelope = ResponseFeedDto.toEnvelopeJSON({
-        records: [record()],
-        days: ['2026-08-24'],
-        projectIds: ['proj-1'],
-        pageSize: 5000,
-        truncated: false,
-        unmatchedSourceKeyCount: 0,
-      });
-
-      expect(envelope.totalCount).to.equal(1);
-      expect(envelope.days).to.deep.equal(['2026-08-24']);
-      expect(envelope.projectIds).to.deep.equal(['proj-1']);
-      expect(envelope.pageSize).to.equal(5000);
-      expect(envelope.truncated).to.equal(false);
-      expect(envelope.unmatchedSourceKeyCount).to.equal(0);
-      expect(envelope.records[0].prompt).to.equal('best running shoes');
-    });
-
-    // Truncation must be visible: it is what separates an incomplete read from a genuinely
-    // quiet day, and a missing tuple is normally legitimate.
-    it('surfaces truncation so a clipped window is not read as a quiet day', () => {
-      const envelope = ResponseFeedDto.toEnvelopeJSON({
-        records: [], days: ['2026-08-24'], truncated: true, unmatchedSourceKeyCount: 3,
-      });
-      expect(envelope.truncated).to.equal(true);
-      expect(envelope.unmatchedSourceKeyCount).to.equal(3);
-    });
-
-    it('renders an empty feed without throwing', () => {
-      expect(ResponseFeedDto.toEnvelopeJSON({})).to.deep.equal({
-        records: [],
-        totalCount: 0,
-        days: [],
-        projectIds: [],
-        pageSize: 0,
-        truncated: false,
-        unmatchedSourceKeyCount: 0,
-      });
+  it('wraps data with page and slice metadata', () => {
+    const page = {
+      offset: 0, pageSize: 500, returned: 1, rowCount: 1, nextOffset: null,
+    };
+    const slice = {
+      geoTargetId: 2840,
+      languageCode: 'en',
+      date: '2026-09-07',
+      model: 'search-gpt',
+    };
+    expect(ResponseFeedDto.toEnvelopeJSON({ data: [row], page, slice })).to.deep.equal({
+      data: [row], page, slice,
     });
   });
 });

--- a/test/it/postgres/brand-claims-responses.test.js
+++ b/test/it/postgres/brand-claims-responses.test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ctx } from './harness.js';
+import { resetPostgres, seedBrandMarketsFixture } from './seed.js';
+import { BRAND_1_ID, ORG_1_ID } from '../shared/seed-ids.js';
+
+describe('Brand Claims response feed persistence boundaries', () => {
+  beforeEach(async () => {
+    await resetPostgres();
+    await seedBrandMarketsFixture();
+  });
+
+  it('rejects a soft-deleted market mapping before constructing an upstream request', async () => {
+    const url = `/v2/orgs/${ORG_1_ID}/brands/${BRAND_1_ID}`
+      + '/serenity/brand-presence/responses'
+      + '?geoTargetId=2276&languageCode=de&date=2026-09-07';
+    const response = await ctx.httpClient.admin.get(url);
+
+    expect(response.status).to.equal(404);
+    expect(response.body.message).to.equal('No owned Semrush project matches the requested market');
+  });
+});

--- a/test/openapi-contract/serenity-api.test.js
+++ b/test/openapi-contract/serenity-api.test.js
@@ -563,31 +563,25 @@ const FIXTURES = {
     usesElementsController: true,
     controllerMethod: 'listResponseFeed',
     serviceMethod: 'getResponseFeed',
-    // from/to are optional (they default to the last 7 days ending yesterday), but are
-    // supplied here so the fixture is deterministic rather than clock-dependent.
-    query: { from: '2026-08-23', to: '2026-08-24' },
-    // getResponseFeed returns the joined shape; the controller maps it through
-    // ResponseFeedDto.toEnvelopeJSON before ok().
+    query: { geoTargetId: '2840', languageCode: 'en', date: '2026-08-24' },
     handlerResult: {
-      records: [{
-        projectId: 'cb4f6443-e01f-4075-a586-85511f136e31',
+      data: [{
+        projectId: 'proj-1',
         prompt: 'best running shoes for flat feet',
-        model: 'chatgpt-paid',
-        date: '2026-08-24',
         response: 'For flat feet, look for stability shoes with firm midsoles.',
-        sources: [{
-          url: 'https://www.runnersworld.com/gear/best-running-shoes',
-          source: 'runnersworld.com',
-          position: 1,
-          domainType: 'Earned',
-        }],
-        sourceRowCount: 1,
+        date: '2026-08-24',
+        model: 'search-gpt',
+        responses: 1,
+        sources: ['https://www.runnersworld.com/gear/best-running-shoes'],
+        tags: ['$abv_tags$intent__commercial'],
       }],
-      days: ['2026-08-23', '2026-08-24'],
-      projectIds: ['cb4f6443-e01f-4075-a586-85511f136e31'],
-      pageSize: 5000,
-      truncated: false,
-      unmatchedSourceKeyCount: 0,
+      page: {
+        offset: 0,
+        pageSize: 500,
+        returned: 1,
+        rowCount: 1,
+        nextOffset: null,
+      },
     },
   },
   listSerenityBrandPresenceSubreddits: {

--- a/test/support/elements/definitions/brand-claims-responses.test.js
+++ b/test/support/elements/definitions/brand-claims-responses.test.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import {
+  buildBrandClaimsResponsesPayload,
+  transformBrandClaimsResponsesResponse,
+} from '../../../../src/support/elements/definitions/brand-claims-responses.js';
+
+const row = (overrides = {}) => ({
+  project_id: 'project-1',
+  prompt: 'Which shoes are best?',
+  response: 'A complete answer',
+  date: '2026-09-07',
+  model: 'search-gpt',
+  responses: 1,
+  sources: ['https://example.com/a'],
+  tags: ['$abv_tags$intent__commercial'],
+  ...overrides,
+});
+
+const raw = (rows = [row()], rowCount = rows.length) => ({
+  blocks: { data: rows, data_statistics: [{ rowCount }] },
+});
+
+describe('brand-claims-responses definition', () => {
+  it('builds the verified exact-Monday, search-gpt, rowCount payload', () => {
+    expect(buildBrandClaimsResponsesPayload({
+      projectId: 'project-1', date: '2026-09-07', pageSize: 500, offset: 1000,
+    })).to.deep.equal({
+      project_id: 'project-1',
+      statistics: { rowCount: { col: '*', func: 'count' } },
+      filters: {
+        simple: { CBF_date__start: '2026-09-07', CBF_date__end: '2026-09-07' },
+        advanced: {
+          op: 'and',
+          filters: [
+            { op: 'or', filters: [{ op: 'eq', val: 'search-gpt', col: 'CBF_model' }] },
+            { op: 'gte', val: '2026-09-07', col: 'CBF_date__start' },
+            { op: 'lte', val: '2026-09-07', col: 'CBF_date__end' },
+          ],
+        },
+      },
+      pagination: {
+        limit: 500,
+        offset: 1000,
+        sort_columns: ['project_id asc', 'prompt asc', 'model asc', 'date asc'],
+      },
+    });
+  });
+
+  it('normalizes the combined row and rowCount without changing source order', () => {
+    const result = transformBrandClaimsResponsesResponse(raw([
+      row({ sources: ['https://example.com/b', 'https://example.com/a'] }),
+    ], 7));
+    expect(result).to.deep.equal({
+      rowCount: 7,
+      data: [{
+        projectId: 'project-1',
+        prompt: 'Which shoes are best?',
+        response: 'A complete answer',
+        date: '2026-09-07',
+        model: 'search-gpt',
+        responses: 1,
+        sources: ['https://example.com/b', 'https://example.com/a'],
+        tags: ['$abv_tags$intent__commercial'],
+      }],
+    });
+  });
+
+  for (const [name, value] of [
+    ['missing envelope', {}],
+    ['missing rowCount', { blocks: { data: [], data_statistics: [] } }],
+    ['negative rowCount', raw([], -1)],
+    ['blank response', raw([row({ response: '   ' })])],
+    ['wrong sources type', raw([row({ sources: 'https://example.com' })])],
+    ['wrong tags item type', raw([row({ tags: [7] })])],
+    ['missing required field', raw([row({ prompt: undefined })])],
+  ]) {
+    it(`rejects schema drift: ${name}`, () => {
+      expect(() => transformBrandClaimsResponsesResponse(value))
+        .to.throw(/Malformed Brand Claims Elements response/);
+    });
+  }
+});

--- a/test/support/elements/definitions/brand-claims-responses.test.js
+++ b/test/support/elements/definitions/brand-claims-responses.test.js
@@ -58,9 +58,12 @@ describe('brand-claims-responses definition', () => {
     });
   });
 
-  it('normalizes the combined row and rowCount without changing source order', () => {
+  it('normalizes the combined row, UTC-midnight date, and rowCount without changing source order', () => {
     const result = transformBrandClaimsResponsesResponse(raw([
-      row({ sources: ['https://example.com/b', 'https://example.com/a'] }),
+      row({
+        date: '2026-09-07T00:00:00Z',
+        sources: ['https://example.com/b', 'https://example.com/a'],
+      }),
     ], 7));
     expect(result).to.deep.equal({
       rowCount: 7,
@@ -84,6 +87,8 @@ describe('brand-claims-responses definition', () => {
     ['blank response', raw([row({ response: '   ' })])],
     ['wrong sources type', raw([row({ sources: 'https://example.com' })])],
     ['wrong tags item type', raw([row({ tags: [7] })])],
+    ['non-midnight date', raw([row({ date: '2026-09-07T12:00:00Z' })])],
+    ['impossible date', raw([row({ date: '2026-02-30' })])],
     ['missing required field', raw([row({ prompt: undefined })])],
   ]) {
     it(`rejects schema drift: ${name}`, () => {

--- a/test/support/elements/elements-transport.test.js
+++ b/test/support/elements/elements-transport.test.js
@@ -195,6 +195,34 @@ describe('createElementsTransport', () => {
       expect(response.cancel).to.have.been.calledOnce;
     });
 
+    it('preserves the typed streamed-overflow error when cancellation fails', async () => {
+      const response = makeStreamingResponse(200, ['1234', '5678']);
+      response.cancel.rejects(new Error('cancel failed'));
+      fetchStub.resolves(response);
+      const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
+
+      await expect(transport.fetchElement(WORKSPACE_ID, ELEMENT_ID, {}, {
+        maxResponseBytes: 7,
+      })).to.be.rejectedWith(ElementsTransportError, /exceeds configured 7-byte limit/);
+      expect(response.cancel).to.have.been.calledOnce;
+    });
+
+    it('best-effort cancels an unread body rejected by Content-Length', async () => {
+      const cancel = sinon.stub().rejects(new Error('cancel failed'));
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        headers: { get: (name) => (name === 'content-length' ? '8' : null) },
+        body: { cancel },
+      });
+      const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
+
+      await expect(transport.fetchElement(WORKSPACE_ID, ELEMENT_ID, {}, {
+        maxResponseBytes: 7,
+      })).to.be.rejectedWith(ElementsTransportError, /exceeds configured 7-byte limit/);
+      expect(cancel).to.have.been.calledOnce;
+    });
+
     it('redacts the workspace from endpoint-specific error descriptors', async () => {
       fetchStub.resolves(makeResponse(500, { error: 'failed' }));
       const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
@@ -369,6 +397,45 @@ describe('createElementsTransport', () => {
         const err = await settledPromise;
         expect(err).to.be.instanceOf(ElementsTransportError);
         expect(err.status).to.equal(504);
+      } finally {
+        clock.restore();
+      }
+    });
+
+    it('keeps the timeout active after headers while the response body is read', async () => {
+      const clock = sinon.useFakeTimers();
+      try {
+        fetchStub.callsFake(async (url, init) => ({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          body: {
+            getReader: () => ({
+              read: () => new Promise((resolve, reject) => {
+                init.signal.addEventListener('abort', () => {
+                  reject(Object.assign(new Error('The operation was aborted'), {
+                    name: 'AbortError',
+                  }));
+                }, { once: true });
+              }),
+              cancel: sinon.stub().resolves(),
+            }),
+          },
+        }));
+        const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
+        const settledPromise = transport.fetchElement(WORKSPACE_ID, ELEMENT_ID, {}, {
+          timeoutMs: 5000,
+          maxResponseBytes: 8 * 1024 * 1024,
+        }).catch((e) => e);
+
+        // Fetch has already returned headers, but its body remains stalled.
+        await clock.tickAsync(4999);
+        await clock.tickAsync(1);
+
+        const err = await settledPromise;
+        expect(err).to.be.instanceOf(ElementsTransportError);
+        expect(err.status).to.equal(504);
+        expect(err.message).to.include('timed out after 5000ms');
       } finally {
         clock.restore();
       }

--- a/test/support/elements/elements-transport.test.js
+++ b/test/support/elements/elements-transport.test.js
@@ -42,6 +42,31 @@ function makeResponse(status, body, headers = {}) {
   };
 }
 
+function makeStreamingResponse(status, chunks) {
+  const encoded = chunks.map((chunk) => new TextEncoder().encode(chunk));
+  let index = 0;
+  const cancel = sinon.stub().resolves();
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (index >= encoded.length) {
+            return { done: true, value: undefined };
+          }
+          const value = encoded[index];
+          index += 1;
+          return { done: false, value };
+        },
+        cancel,
+      }),
+    },
+    cancel,
+  };
+}
+
 describe('createElementsTransport', () => {
   let fetchStub;
   let originalFetch;
@@ -148,6 +173,44 @@ describe('createElementsTransport', () => {
       const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
       const result = await transport.fetchElement(WORKSPACE_ID, ELEMENT_ID, {});
       expect(result).to.deep.equal(responseBody);
+    });
+
+    it('accepts a response exactly at the per-call decompressed byte ceiling', async () => {
+      const body = JSON.stringify({ ok: true });
+      fetchStub.resolves(makeStreamingResponse(200, [body]));
+      const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
+      const result = await transport.fetchElement(WORKSPACE_ID, ELEMENT_ID, {}, {
+        maxResponseBytes: new TextEncoder().encode(body).byteLength,
+      });
+      expect(result).to.deep.equal({ ok: true });
+    });
+
+    it('cancels and rejects a streamed response above the decompressed byte ceiling', async () => {
+      const response = makeStreamingResponse(200, ['1234', '5678']);
+      fetchStub.resolves(response);
+      const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
+      await expect(transport.fetchElement(WORKSPACE_ID, ELEMENT_ID, {}, {
+        maxResponseBytes: 7,
+      })).to.be.rejectedWith(ElementsTransportError, /exceeds configured 7-byte limit/);
+      expect(response.cancel).to.have.been.calledOnce;
+    });
+
+    it('redacts the workspace from endpoint-specific error descriptors', async () => {
+      fetchStub.resolves(makeResponse(500, { error: 'failed' }));
+      const transport = createElementsTransport({ env: ENV, imsToken: IMS_TOKEN });
+      let error;
+      try {
+        await transport.fetchElement(WORKSPACE_ID, ELEMENT_ID, {}, {
+          redactWorkspaceInErrors: true,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error.workspaceId).to.equal(undefined);
+      expect(error.endpoint).to.include('/workspaces/[redacted]/');
+      expect(error.endpoint).to.not.include(WORKSPACE_ID);
+      expect(error.message).to.include('/workspaces/[redacted]/');
+      expect(error.message).to.not.include(WORKSPACE_ID);
     });
 
     it('URL-encodes workspaceId in the path', async () => {

--- a/test/support/elements/response-feed-service.test.js
+++ b/test/support/elements/response-feed-service.test.js
@@ -11,43 +11,28 @@
  */
 
 import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { createElementsService } from '../../../src/support/elements/elements-service.js';
 import { ELEMENT_IDS } from '../../../src/support/elements/element-ids.js';
 
+use(chaiAsPromised);
 use(sinonChai);
 
-const WS = 'ws-1';
-const PROJECT = 'proj-1';
-
-/** Builds a raw answer-element page (141adc88 — no date column). */
-const answerPage = (rows) => ({ blocks: { data: rows } });
-
-/** Builds one answer row. */
-const answer = (over = {}) => ({
-  project_id: PROJECT,
-  prompt: 'best running shoes',
-  model: 'chatgpt-paid',
-  response: 'Some answer text',
-  position: 1,
-  tags: '',
-  ...over,
+const row = (overrides = {}) => ({
+  project_id: 'project-1',
+  prompt: 'Which shoes are best?',
+  response: 'A complete answer',
+  date: '2026-09-07',
+  model: 'search-gpt',
+  responses: 1,
+  sources: [],
+  tags: [],
+  ...overrides,
 });
-
-/** Builds one source row. The live element returns a full timestamp for `date`. */
-const source = (over = {}) => ({
-  project_id: PROJECT,
-  prompt: 'best running shoes',
-  model: 'chatgpt-paid',
-  date: '2026-08-24T00:00:00Z',
-  url_cbf: 'https://runnersworld.com/best',
-  source: 'runnersworld.com',
-  position: 1,
-  domain_type: 'Earned',
-  execution_id: 'exec-1',
-  tags: '',
-  ...over,
+const page = (rows, rowCount) => ({
+  blocks: { data: rows, data_statistics: [{ rowCount }] },
 });
 
 describe('createElementsService#getResponseFeed', () => {
@@ -56,353 +41,93 @@ describe('createElementsService#getResponseFeed', () => {
 
   beforeEach(() => {
     transport = { fetchElement: sinon.stub() };
-    transport.fetchElement.resolves(answerPage([]));
     service = createElementsService(transport);
   });
 
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  /** All `endDate` values the answer element was called with, in call order. */
-  const answerBoundaries = () => transport.fetchElement
-    .getCalls()
-    .filter((c) => c.args[1] === ELEMENT_IDS.CITATIONS_SOURCES)
-    .map((c) => c.args[2].filters.simple.CBF_date__end);
-
-  describe('boundary amortisation', () => {
-    // The reason this endpoint is range-based rather than per-day. Recovering N days needs
-    // N+1 boundaries because consecutive days SHARE one: executions(D) = end(D) - end(D-1),
-    // so end(D) is also the subtrahend for day D+1. Fetching per-day would cost 2N.
-    it('costs N+1 boundary pulls per element for an N-day range, not 2N', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-20',
-        endDate: '2026-08-24',
-      });
-
-      // 5 days -> 6 boundaries per element. Naive per-day would be 10.
-      expect(answerBoundaries()).to.have.lengthOf(6);
-      // Two elements, one call each per boundary.
-      expect(transport.fetchElement.callCount).to.equal(12);
+  it('makes exactly one combined-element request for one project page', async () => {
+    transport.fetchElement.resolves(page([row()], 1));
+    const result = await service.getResponseFeed('workspace-1', {
+      projectId: 'project-1', date: '2026-09-07', offset: 0, pageSize: 500,
     });
 
-    it('fetches each boundary exactly once, never re-pulling a shared one', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-20',
-        endDate: '2026-08-24',
-      });
-
-      const boundaries = answerBoundaries();
-      expect(new Set(boundaries).size).to.equal(boundaries.length);
-    });
-
-    it('includes the D-1 boundary before the first requested day', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-20',
-        endDate: '2026-08-22',
-      });
-
-      expect(answerBoundaries()).to.deep.equal([
-        '2026-08-19', '2026-08-20', '2026-08-21', '2026-08-22',
-      ]);
-    });
-
-    it('costs 2 pulls per element for a single-day range (the degenerate case)', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(answerBoundaries()).to.deep.equal(['2026-08-23', '2026-08-24']);
+    expect(transport.fetchElement).to.have.been.calledOnceWith(
+      'workspace-1',
+      ELEMENT_IDS.BRAND_CLAIMS_RESPONSES,
+      sinon.match({ project_id: 'project-1' }),
+      sinon.match({
+        maxResponseBytes: 8 * 1024 * 1024,
+        redactWorkspaceInErrors: true,
+      }),
+    );
+    expect(result.page).to.deep.equal({
+      offset: 0, pageSize: 500, returned: 1, rowCount: 1, nextOffset: null,
     });
   });
 
-  describe('the join', () => {
-    it('pairs an answer with the sources cited in the same execution', async () => {
-      transport.fetchElement.callsFake((ws, elementId, payload) => {
-        const end = payload.filters.simple.CBF_date__end;
-        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
-          // Present on day D, absent on D-1 -> a genuine day-D execution.
-          return Promise.resolve(answerPage(end === '2026-08-24' ? [answer()] : []));
-        }
-        return Promise.resolve(answerPage(end === '2026-08-24' ? [source()] : []));
-      });
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.records).to.have.lengthOf(1);
-      expect(result.records[0].sources).to.have.lengthOf(1);
-      expect(result.records[0].date).to.equal('2026-08-24');
-      expect(result.records[0].model).to.equal('chatgpt-paid');
+  it('passes an endpoint-configured upstream byte ceiling to the transport', async () => {
+    transport.fetchElement.resolves(page([], 0));
+    await service.getResponseFeed('workspace-1', {
+      projectId: 'project-1',
+      date: '2026-09-07',
+      offset: 0,
+      pageSize: 500,
+      maxUpstreamBytes: 1234,
     });
-
-    // ABSENCE IS MEANINGFUL: a tuple runs on a median 61 of 74 days, so a model that did
-    // not run is routine and must never read as an error or as lost data.
-    it('returns an answer with an empty source list rather than dropping it', async () => {
-      transport.fetchElement.callsFake((ws, elementId, payload) => {
-        const end = payload.filters.simple.CBF_date__end;
-        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
-          return Promise.resolve(answerPage(end === '2026-08-24' ? [answer()] : []));
-        }
-        return Promise.resolve(answerPage([]));
-      });
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.records).to.have.lengthOf(1);
-      expect(result.records[0].sources).to.deep.equal([]);
-    });
-
-    it('reports no records for a day on which nothing ran, without erroring', async () => {
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.records).to.deep.equal([]);
-      expect(result.unmatchedSourceKeyCount).to.equal(0);
-    });
-
-    // Guards the `?? []` fallbacks: an element answering with no `blocks.data` at all is a
-    // legitimate empty read, not a malformed response, and must not throw mid-join.
-    it('tolerates an element page with no data block', async () => {
-      transport.fetchElement.resolves({});
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-23',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.records).to.deep.equal([]);
-      expect(result.days).to.deep.equal(['2026-08-23', '2026-08-24']);
-    });
-
-    // A row present on BOTH boundaries is carried-over history, not a day-D execution.
-    it('excludes an answer already present on the previous boundary', async () => {
-      transport.fetchElement.resolves(answerPage([answer()]));
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.records).to.deep.equal([]);
-    });
-
-    it('selects source rows by their own date rather than by difference', async () => {
-      transport.fetchElement.callsFake((ws, elementId, payload) => {
-        const end = payload.filters.simple.CBF_date__end;
-        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
-          return Promise.resolve(answerPage(end === '2026-08-24' ? [answer()] : []));
-        }
-        // The page holds the whole rolling window; only the day's own rows must join.
-        return Promise.resolve(answerPage([
-          source({ date: '2026-08-23T00:00:00Z', url_cbf: 'https://old.example' }),
-          source(),
-        ]));
-      });
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.records[0].sources).to.have.lengthOf(1);
-      expect(result.records[0].sources[0].url).to.equal('https://runnersworld.com/best');
-    });
-
-    it('counts source rows whose answer was not in the page', async () => {
-      transport.fetchElement.callsFake((ws, elementId) => {
-        if (elementId === ELEMENT_IDS.CITATIONS_SOURCES) {
-          return Promise.resolve(answerPage([]));
-        }
-        return Promise.resolve(answerPage([source()]));
-      });
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.unmatchedSourceKeyCount).to.equal(1);
+    expect(transport.fetchElement.firstCall.args[3]).to.include({
+      maxResponseBytes: 1234,
+      redactWorkspaceInErrors: true,
     });
   });
 
-  describe('project (market) fan-out', () => {
-    it('issues an independent boundary walk per project', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: ['p1', 'p2'],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      // 2 projects x 2 boundaries x 2 elements.
-      expect(transport.fetchElement.callCount).to.equal(8);
-      const scoped = transport.fetchElement.getCalls().map((c) => c.args[2].project_id);
-      expect(new Set(scoped)).to.deep.equal(new Set(['p1', 'p2']));
+  it('returns the next offset while rows remain', async () => {
+    transport.fetchElement.resolves(page(Array.from({ length: 500 }, () => row()), 1296));
+    const result = await service.getResponseFeed('workspace-1', {
+      projectId: 'project-1', date: '2026-09-07', offset: 500, pageSize: 500,
     });
-
-    it('deduplicates repeated project ids so a market is not walked twice', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: ['p1', 'p1'],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(transport.fetchElement.callCount).to.equal(4);
-    });
-
-    it('omits project_id entirely when no project is supplied', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(transport.fetchElement.callCount).to.equal(4);
-      expect(transport.fetchElement.firstCall.args[2]).to.not.have.property('project_id');
-    });
-
-    it('treats a missing projectIds as workspace-wide rather than throwing', async () => {
-      const result = await service.getResponseFeed(WS, {
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.projectIds).to.deep.equal([]);
-    });
-
-    it('ignores blank project ids', async () => {
-      const result = await service.getResponseFeed(WS, {
-        projectIds: ['', '  '],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.projectIds).to.deep.equal([]);
-    });
-
-    it('ignores a null project id without throwing', async () => {
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [null, undefined],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.projectIds).to.deep.equal([]);
-    });
+    expect(result.page.nextOffset).to.equal(1000);
   });
 
-  describe('envelope', () => {
-    it('reports the days covered and the resolved page size', async () => {
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-23',
-        endDate: '2026-08-24',
-      });
-
-      expect(result.days).to.deep.equal(['2026-08-23', '2026-08-24']);
-      expect(result.pageSize).to.equal(5000);
-      expect(result.truncated).to.equal(false);
+  it('terminates an exact-multiple corpus without requesting an empty page', async () => {
+    transport.fetchElement.resolves(page(Array.from({ length: 500 }, () => row()), 1000));
+    const result = await service.getResponseFeed('workspace-1', {
+      projectId: 'project-1', date: '2026-09-07', offset: 500, pageSize: 500,
     });
-
-    it('honours a caller-supplied limit in the resolved page size', async () => {
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-        limit: 10,
-      });
-
-      expect(result.pageSize).to.equal(10);
-    });
-
-    // A full page means the window was clipped, so the difference may be incomplete. That
-    // must be visible: silently serving a partial day as whole is the data-loss shape.
-    it('flags truncation when an upstream page comes back full', async () => {
-      transport.fetchElement.resolves(answerPage([answer(), answer()]));
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-        limit: 2,
-      });
-
-      expect(result.truncated).to.equal(true);
-    });
-
-    it('does not flag truncation on a partial page', async () => {
-      transport.fetchElement.resolves(answerPage([answer()]));
-
-      const result = await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-        limit: 500,
-      });
-
-      expect(result.truncated).to.equal(false);
-    });
+    expect(result.page.nextOffset).to.equal(null);
+    expect(transport.fetchElement).to.have.been.calledOnce;
   });
 
-  describe('upstream payloads', () => {
-    it('reads both halves of the record from their own elements', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      const ids = new Set(transport.fetchElement.getCalls().map((c) => c.args[1]));
-      expect(ids).to.deep.equal(new Set([
-        ELEMENT_IDS.CITATIONS_SOURCES,
-        ELEMENT_IDS.SOURCES_DATES,
-      ]));
+  it('accepts a genuinely empty corpus at offset zero', async () => {
+    transport.fetchElement.resolves(page([], 0));
+    const result = await service.getResponseFeed('workspace-1', {
+      projectId: 'project-1', date: '2026-09-07', offset: 0, pageSize: 500,
     });
+    expect(result.page).to.include({ returned: 0, rowCount: 0, nextOffset: null });
+  });
 
-    it('passes the model filter through to both elements', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-        model: 'perplexity',
-      });
+  it('rejects a spurious empty page for a non-empty corpus', async () => {
+    transport.fetchElement.resolves(page([], 1000));
+    await expect(service.getResponseFeed('workspace-1', {
+      projectId: 'project-1', date: '2026-09-07', offset: 1000, pageSize: 500,
+    })).to.be.rejectedWith('empty nonterminal page');
+  });
 
-      for (const call of transport.fetchElement.getCalls()) {
-        const modelFilter = call.args[2].filters.advanced.filters
-          .find((f) => f.op === 'or');
-        expect(modelFilter.filters[0].val).to.equal('perplexity');
-      }
-    });
+  it('rejects impossible pagination metadata', async () => {
+    transport.fetchElement.resolves(page([row(), row()], 1));
+    await expect(service.getResponseFeed('workspace-1', {
+      projectId: 'project-1', date: '2026-09-07', offset: 0, pageSize: 500,
+    })).to.be.rejectedWith('pagination metadata');
+  });
 
-    it('targets the resolved workspace, which the caller never supplies', async () => {
-      await service.getResponseFeed(WS, {
-        projectIds: [PROJECT],
-        startDate: '2026-08-24',
-        endDate: '2026-08-24',
-      });
-
-      for (const call of transport.fetchElement.getCalls()) {
-        expect(call.args[0]).to.equal(WS);
-      }
+  [
+    ['another project', { project_id: 'project-2' }],
+    ['another date', { date: '2026-09-08' }],
+    ['another model', { model: 'perplexity' }],
+  ].forEach(([description, changed]) => {
+    it(`rejects a row from ${description}`, async () => {
+      transport.fetchElement.resolves(page([row(changed)], 1));
+      await expect(service.getResponseFeed('workspace-1', {
+        projectId: 'project-1', date: '2026-09-07', offset: 0, pageSize: 500,
+      })).to.be.rejectedWith('outside the requested slice');
     });
   });
 });

--- a/test/support/elements/response-feed-service.test.js
+++ b/test/support/elements/response-feed-service.test.js
@@ -55,6 +55,8 @@ describe('createElementsService#getResponseFeed', () => {
       ELEMENT_IDS.BRAND_CLAIMS_RESPONSES,
       sinon.match({ project_id: 'project-1' }),
       sinon.match({
+        timeoutMs: 20_000,
+        maxRetries: 0,
         maxResponseBytes: 8 * 1024 * 1024,
         redactWorkspaceInErrors: true,
       }),
@@ -74,6 +76,8 @@ describe('createElementsService#getResponseFeed', () => {
       maxUpstreamBytes: 1234,
     });
     expect(transport.fetchElement.firstCall.args[3]).to.include({
+      timeoutMs: 20_000,
+      maxRetries: 0,
       maxResponseBytes: 1234,
       redactWorkspaceInErrors: true,
     });


### PR DESCRIPTION
## Summary

Replaces the existing multi-element Brand Claims response-feed assembly with one synchronous page from custom Semrush element `55e89619-4b02-4319-be91-590e58da8815`.

Builds on the S2S transport and `SEMRUSH_ADMIN_ELEMENT_API_KEY` introduced by #3217.

## Behavior

- Requires one owned `geoTargetId` + `languageCode` market and one exact Monday.
- Fixes the upstream model to `search-gpt`.
- Resolves workspace and project server-side; callers cannot supply either.
- Defaults/caps page size at 500.
- Validates row shape, project/date/model, nonblank responses, invariant `rowCount`, and exact-multiple pagination.
- Preserves source-array order and duplicate occurrences for citation-index semantics.
- Rejects tombstoned mappings before any Semrush call.
- Adds bounded upstream and serialized outbound response-size guards.
- Uses a 20s whole-response upstream deadline with no in-request retry; Mystique retries failed pages separately.
- Normalizes the live UTC-midnight execution date to the public `YYYY-MM-DD` contract.
- Redacts workspace IDs and hashes brand identifiers in endpoint error telemetry.
- Keeps S2S fail-closed with no legacy credential fallback.

## Related Issues / PRs

- Follow-up to #3217.
- Standalone V1 design authority: adobe/mysticat-architecture#295.

No separate issue was created; this PR implements the synchronous Brand Claims ingestion contract described above.

## Validation

- Live bounded load probe: 8 calls at concurrency 4; max 7.31s, max upstream 2,494,066 bytes, max outbound 2,493,595 bytes.
- Post-fix implementation probe: 4 concurrent real pages; max 7.896s, max outbound 2,488,595 bytes; all passed 20s/5 MiB limits.
- Default headroom at the measured maximum: about 70% below the 8 MiB upstream limit and 52% below the 5 MiB outbound limit.
- Deterministic stalled-body test proves the timeout covers body consumption after headers.
- Focused timeout/limit/date tests: **78 passing**.
- Broader affected suite after fixes: **4,432 passing**.
- `npm run lint`: passed.
- `npm run type-check`: passed.
- `npm run docs:lint`: passed, with existing repository warnings.
- Earlier GitHub CI PostgreSQL integration, build, type-check, branch deploy, title validation, and Codecov patch: passed; rerun pending on the latest head.
- Two fresh local blockers-only reviews completed; final verdict: PASS.

## Open gates

- Semrush confirmation that custom-element `sources[n-1]` corresponds to citation `[n]`, preserving order and duplicates.
- Shared-key fleet admission before production enablement; intentionally outside this code change.
- MysticatBot rereview and GitHub CI on the latest head.

## Checklist

- [x] Related PRs and problem described.
- [x] API specification and examples updated.
- [x] API implementation matches the specification.
- [x] Focused, affected, lint, type, and OpenAPI checks run.
- [x] Local live timeout and byte-limit validation completed.
- [ ] Latest-head GitHub CI and MysticatBot rereview complete.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: moderate
risk: moderate
scope: single-repo
relatedPRs:
  - adobe/spacecat-api-service#3217
  - adobe/mysticat-architecture#295
rationale: "Replace legacy multi-element Brand Claims response assembly with a bounded, tenant-owned synchronous combined-element page contract."
recommendations: "Keep production activation gated on the documented Semrush contract and fleet-admission decisions."
backout: "Disable the consumer rollout and revert this PR; the endpoint is not activated by this change alone."
```