### PR TITLE
fix: require Fix entity for FIXED status on gated opport…

### DIFF
--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -4301,6 +4301,15 @@ FixCreate:
       description: Optional array of suggestion IDs to associate with this fix
       items:
         $ref: '#/Id'
+    suggestionsTargetStatus:
+      $ref: '#/SuggestionStatus'
+      description: >-
+        Optional. When set, the suggestions in suggestionIds are atomically
+        transitioned to this status once this fix is successfully created and linked.
+        Required for opportunity types where a suggestion cannot be marked FIXED
+        without a corresponding Fix entity (see PATCH suggestion status endpoints,
+        which reject direct transitions to FIXED for those types). Omit to leave
+        suggestion status untouched.
 
 FixOperationSuccess:
   type: object
@@ -4423,6 +4432,14 @@ FixStatusUpdate:
       status:
         description: Status of this fix; status reflects overall fix execution, flagged here for optimization
         $ref: '#/SuggestionStatus'
+      suggestionsTargetStatus:
+        $ref: '#/SuggestionStatus'
+        description: >-
+          Optional. When set, the fix's linked suggestions are atomically
+          transitioned to this status once the fix status update is successfully
+          persisted. Required for opportunity types where a suggestion cannot be
+          marked FIXED without a corresponding Fix entity. Omit to leave
+          suggestion status untouched.
     required:
       - id
       - status

--- a/docs/openapi/schemas.yaml
+++ b/docs/openapi/schemas.yaml
@@ -4324,6 +4324,15 @@ FixOperationSuccess:
       type: integer
     fix:
       $ref: '#/Fix'
+    suggestions:
+      type: array
+      description: >-
+        Present only when suggestionsTargetStatus was provided in the request for
+        this fix and linked suggestions were transitioned as a result. Reflects
+        each suggestion's post-transition state, so the caller can sync local state
+        without a separate fetch. Absent when suggestionsTargetStatus was not set.
+      items:
+        $ref: '#/Suggestion'
   required:
     - index
     - statusCode

--- a/docs/openapi/site-opportunities.yaml
+++ b/docs/openapi/site-opportunities.yaml
@@ -511,6 +511,12 @@ site-opportunity-suggestions-status:
       call this endpoint. The admin-only gate for `REJECTED` status transitions is bypassed
       for S2S callers holding this capability; all other validations (site membership,
       opportunity lookup, valid status transition) apply unchanged.
+
+      **FIXED status:** for opportunity types where a suggestion must have a corresponding
+      Fix entity before it can be FIXED, a direct transition to FIXED via this endpoint is
+      rejected with a 400. Use `POST .../opportunities/{opportunityId}/fixes` with
+      `suggestionsTargetStatus: FIXED` instead, which creates the Fix and transitions
+      the suggestion atomically.
     tags:
       - opportunity-suggestions
     requestBody:
@@ -1375,6 +1381,12 @@ site-opportunity-suggestion:
     operationId: updateSiteOpportunitySuggestion
     summary: |
       Update specific attributes of an existing suggestion
+    description: |
+      For opportunity types where a suggestion must have a corresponding Fix entity
+      before it can be FIXED, a direct transition to FIXED via this endpoint is
+      rejected with a 400. Use `POST .../opportunities/{opportunityId}/fixes` with
+      `suggestionsTargetStatus: FIXED` instead, which creates the Fix and transitions
+      the suggestion atomically.
     tags:
       - opportunity-suggestions
     requestBody:
@@ -1800,9 +1812,15 @@ site-opportunity-fixes:
     summary: |
       Create and add a list of one or more fixes to an opportunity in one transaction
     description: |
-      Creates one or more fix entities for a given opportunity. Each fix can optionally include 
-      an array of suggestionIds to associate existing suggestions with the fix. This allows you 
+      Creates one or more fix entities for a given opportunity. Each fix can optionally include
+      an array of suggestionIds to associate existing suggestions with the fix. This allows you
       to link fixes to the suggestions they address in a single transaction.
+
+      Set `suggestionsTargetStatus` on a fix to also transition its linked
+      suggestions to that status once the fix is successfully created and linked —
+      atomically, so a suggestion is never marked FIXED without a persisted Fix entity.
+      This is required for opportunity types where the suggestion-status PATCH
+      endpoints reject a direct transition to FIXED.
     tags:
       - opportunity-fixes
     requestBody:
@@ -2042,6 +2060,12 @@ site-opportunity-status:
     operationId: updateSiteOpportunityStatus
     summary: |
       Update the status of one or multiple fixes in one transaction
+    description: |
+      Set `suggestionsTargetStatus` on a fix update to also transition its linked
+      suggestions to that status once the fix status update is successfully
+      persisted — atomically, so a suggestion is never transitioned independently of
+      the fix update. This is required for opportunity types where the
+      suggestion-status PATCH endpoints reject a direct transition to FIXED.
     tags:
       - opportunity-fixes
     requestBody:

--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -422,6 +422,23 @@ export class FixesController {
           return dedupedResult;
         }
 
+        // Resolve and validate suggestionIds before creating the fix, so an invalid
+        // suggestion ID (unknown, or belonging to a different opportunity) fails fast
+        // without leaving behind an orphaned, unlinked FixEntity.
+        let suggestions;
+        if (fixData.suggestionIds) {
+          suggestions = await Promise.all(
+            fixData.suggestionIds.map((id) => this.#Suggestion.findById(id)),
+          );
+          if (suggestions.some((s) => !s || s.getOpportunityId() !== opportunityId)) {
+            return {
+              index,
+              message: 'Invalid suggestion IDs',
+              statusCode: 400,
+            };
+          }
+        }
+
         const enrichedFixData = await FixesController.#enrichWithDocumentPath(
           fixData,
           enrichmentCtx,
@@ -438,11 +455,21 @@ export class FixesController {
           opportunityId,
           ...(hasText(callerUserId) && { executedBy: callerUserId }),
         });
-        if (fixData.suggestionIds) {
-          const suggestions = await Promise.all(
-            fixData.suggestionIds.map((id) => this.#Suggestion.findById(id)),
-          );
+        if (suggestions) {
           await FixEntity.setSuggestionsForFixEntity(opportunityId, fixEntity, suggestions);
+
+          // Opt-in (SITES-fix-orphan): the fix has just been persisted and linked, so
+          // it's safe to transition these suggestions to the caller-specified status
+          // atomically with fix creation. Only reached after
+          // FixEntity.create/setSuggestionsForFixEntity succeeded above; a failure
+          // there throws before this line, so a suggestion is never transitioned
+          // without a persisted, linked fix.
+          if (hasText(fixData.suggestionsTargetStatus)) {
+            await this.#Suggestion.bulkUpdateStatus(
+              suggestions,
+              fixData.suggestionsTargetStatus,
+            );
+          }
         }
         return {
           index,
@@ -652,7 +679,14 @@ export class FixesController {
 
     const fixes = await Promise.all(
       context.data.map(
-        (data, index) => this.#patchFixStatus(data.id, data.status, index, opportunityId, siteId),
+        (data, index) => this.#patchFixStatus(
+          data.id,
+          data.status,
+          index,
+          opportunityId,
+          siteId,
+          data.suggestionsTargetStatus,
+        ),
       ),
     );
     const succeeded = countSucceeded(fixes);
@@ -662,7 +696,7 @@ export class FixesController {
     }, 207);
   }
 
-  async #patchFixStatus(uuid, status, index, opportunityId, siteId) {
+  async #patchFixStatus(uuid, status, index, opportunityId, siteId, suggestionsTargetStatus) {
     if (!hasText(uuid)) {
       return {
         index,
@@ -701,8 +735,20 @@ export class FixesController {
       }
 
       fix.setStatus(status);
+      const updatedFix = await fix.save();
+
+      // Opt-in (mirrors createFixes' suggestionsTargetStatus): only reached after the
+      // fix status write above succeeded, so a suggestion is never transitioned
+      // without a persisted fix status update.
+      if (hasText(suggestionsTargetStatus)) {
+        const suggestions = await this.#FixEntity.getSuggestionsByFixEntityId(uuid);
+        if (Array.isArray(suggestions) && suggestions.length > 0) {
+          await this.#Suggestion.bulkUpdateStatus(suggestions, suggestionsTargetStatus);
+        }
+      }
+
       return {
-        index, uuid, fix: FixDto.toJSON(await fix.save()), statusCode: 200,
+        index, uuid, fix: FixDto.toJSON(updatedFix), statusCode: 200,
       };
     } catch (error) {
       const statusCode = error?.name === VALIDATION_ERROR_NAME ? /* c8 ignore next */ 400 : 500;

--- a/src/controllers/fixes.js
+++ b/src/controllers/fixes.js
@@ -455,6 +455,7 @@ export class FixesController {
           opportunityId,
           ...(hasText(callerUserId) && { executedBy: callerUserId }),
         });
+        let updatedSuggestions;
         if (suggestions) {
           await FixEntity.setSuggestionsForFixEntity(opportunityId, fixEntity, suggestions);
 
@@ -465,7 +466,7 @@ export class FixesController {
           // there throws before this line, so a suggestion is never transitioned
           // without a persisted, linked fix.
           if (hasText(fixData.suggestionsTargetStatus)) {
-            await this.#Suggestion.bulkUpdateStatus(
+            updatedSuggestions = await this.#Suggestion.bulkUpdateStatus(
               suggestions,
               fixData.suggestionsTargetStatus,
             );
@@ -474,6 +475,12 @@ export class FixesController {
         return {
           index,
           fix: FixDto.toJSON(fixEntity),
+          // Only present when suggestionsTargetStatus was provided — callers that
+          // didn't mutate suggestion status get no suggestions field, since nothing
+          // about suggestion state changed for them to sync.
+          ...(updatedSuggestions && {
+            suggestions: updatedSuggestions.map((s) => SuggestionDto.toJSON(s)),
+          }),
           statusCode: 201,
         };
       } catch (error) {
@@ -740,15 +747,27 @@ export class FixesController {
       // Opt-in (mirrors createFixes' suggestionsTargetStatus): only reached after the
       // fix status write above succeeded, so a suggestion is never transitioned
       // without a persisted fix status update.
+      let updatedSuggestions;
       if (hasText(suggestionsTargetStatus)) {
         const suggestions = await this.#FixEntity.getSuggestionsByFixEntityId(uuid);
         if (Array.isArray(suggestions) && suggestions.length > 0) {
-          await this.#Suggestion.bulkUpdateStatus(suggestions, suggestionsTargetStatus);
+          updatedSuggestions = await this.#Suggestion.bulkUpdateStatus(
+            suggestions,
+            suggestionsTargetStatus,
+          );
         }
       }
 
       return {
-        index, uuid, fix: FixDto.toJSON(updatedFix), statusCode: 200,
+        index,
+        uuid,
+        fix: FixDto.toJSON(updatedFix),
+        // Only present when suggestionsTargetStatus was provided and linked
+        // suggestions actually existed to transition.
+        ...(updatedSuggestions && {
+          suggestions: updatedSuggestions.map((s) => SuggestionDto.toJSON(s)),
+        }),
+        statusCode: 200,
       };
     } catch (error) {
       const statusCode = error?.name === VALIDATION_ERROR_NAME ? /* c8 ignore next */ 400 : 500;

--- a/src/controllers/suggestions.js
+++ b/src/controllers/suggestions.js
@@ -58,6 +58,7 @@ import {
   isImpactMeasurementEligible,
 } from '../support/geo-experiment-helper.js';
 import { FixDto } from '../dto/fix.js';
+import { SUGGESTION_TYPES_REQUIRING_FIX_ENTITY } from '../utils/suggestion-fix-required-types.js';
 import { GeoExperimentDto } from '../dto/geo-experiment.js';
 import {
   sendAutofixMessage,
@@ -1149,6 +1150,12 @@ function SuggestionsController(ctx, sqs, env) {
 
       let isNewSkipTransition = false;
       if (hasText(status) && status !== suggestion.getStatus()) {
+        if (
+          status === SuggestionModel.STATUSES.FIXED
+          && SUGGESTION_TYPES_REQUIRING_FIX_ENTITY.includes(opportunity.getType())
+        ) {
+          return badRequest(`Suggestions of type '${opportunity.getType()}' cannot be marked FIXED directly; create a Fix via POST /sites/:siteId/opportunities/:opportunityId/fixes with suggestionsTargetStatus: FIXED instead.`);
+        }
         const { valid, error } = validateSkipFields(status, skipReason, skipDetail);
         if (!valid) {
           return badRequest(error);
@@ -1366,6 +1373,23 @@ function SuggestionsController(ctx, sqs, env) {
                 statusCode: 400,
               };
             }
+          }
+
+          // FIXED requires a Fix entity for these types (data-integrity gate): reject
+          // a direct transition to FIXED via this generic status endpoint and point
+          // callers at the fix-creation endpoint, which creates the Fix and flips
+          // suggestion status atomically. Checked ahead of the general transition
+          // gate below for the same reason the REJECTED rule is.
+          if (
+            status === SuggestionModel.STATUSES.FIXED
+            && SUGGESTION_TYPES_REQUIRING_FIX_ENTITY.includes(opportunity.getType())
+          ) {
+            return {
+              index,
+              uuid: id,
+              message: `Suggestions of type '${opportunity.getType()}' cannot be marked FIXED directly; create a Fix via POST /sites/:siteId/opportunities/:opportunityId/fixes with suggestionsTargetStatus: FIXED instead.`,
+              statusCode: 400,
+            };
           }
 
           // Per-item transition-legality gate (SITES-49063; part of the SITES-47286

--- a/src/utils/suggestion-fix-required-types.js
+++ b/src/utils/suggestion-fix-required-types.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Opportunity types whose suggestions must never be transitioned to FIXED via the
+ * plain suggestion-status PATCH endpoints (`PATCH .../suggestions/:suggestionId` or
+ * `PATCH .../suggestions/status`). For these types a FixEntity is expected to exist
+ * before a suggestion is FIXED, so the transition must go through
+ * `POST .../opportunities/:opportunityId/fixes` (with `markSuggestionsFixed: true`)
+ * instead, which creates the FixEntity and flips the suggestion status atomically.
+ *
+ * `generic-opportunity` is deliberately excluded: it's a shared fallback type used by
+ * several unrelated flows (cwv-trends, accessibility reports, hreflang/canonical paid
+ * fallback), not a single semantic opportunity type, so blocking it would over-restrict
+ * unrelated suggestions.
+ */
+export const SUGGESTION_TYPES_REQUIRING_FIX_ENTITY = [
+  'cwv',
+  'alt-text',
+  'broken-backlinks',
+  'broken-internal-links',
+  'security-vulnerabilities',
+  'security-permissions',
+  'security-permissions-redundant',
+  'security-csp',
+  'structured-data',
+  'meta-tags',
+  'hreflang',
+  'redirect-chains',
+  'sitemap',
+  'canonical',
+  'accessibility',
+  'a11y-color-contrast',
+  'form-accessibility',
+  'high-organic-low-ctr',
+  'high-form-views-low-conversions',
+  'high-page-views-low-form-nav',
+  'high-page-views-low-form-views',
+];

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -1957,7 +1957,7 @@ describe('Fixes Controller', () => {
       expect(fixEntityCollection.setSuggestionsForFixEntity).to.have.been.calledTwice;
     });
 
-    it('handles invalid suggestion IDs during fix creation', async () => {
+    it('handles invalid suggestion IDs during fix creation without creating an orphaned fix', async () => {
       const validSuggestion = await createSuggestion({ type: 'CONTENT_UPDATE' });
       const invalidSuggestionId = '15345195-62e6-494c-81b1-1d0da0b51d84';
 
@@ -1968,9 +1968,7 @@ describe('Fixes Controller', () => {
       };
       requestContext.data = [fixData];
 
-      // Configure validation failure in setSuggestionsForFixEntity
       suggestionCollection.findById.withArgs(invalidSuggestionId).resolves(null);
-      fixEntityCollection.setSuggestionsForFixEntity.rejects(new Error('Invalid suggestion IDs'));
 
       const response = await fixesController.createFixes(requestContext);
       expect(response).includes({ status: 207 });
@@ -1978,8 +1976,92 @@ describe('Fixes Controller', () => {
       const { fixes, metadata } = await response.json();
       expect(metadata).deep.equals({ total: 1, success: 0, failed: 1 });
       expect(fixes).have.lengthOf(1);
-      expect(fixes[0]).includes({ index: 0, statusCode: 500 });
-      expect(fixes[0].message).to.include('Invalid suggestion IDs');
+      expect(fixes[0]).includes({ index: 0, statusCode: 400, message: 'Invalid suggestion IDs' });
+      // No fix should have been created for an invalid suggestionIds batch.
+      expect(fixEntityCollection.setSuggestionsForFixEntity).to.not.have.been.called;
+    });
+
+    it('rejects suggestion IDs belonging to a different opportunity', async () => {
+      const otherOpportunityId = 'b3d2f1e9-5f4c-4e6b-8c7d-0c7b5a2f1a2f';
+      const foreignSuggestion = await createSuggestion({
+        type: 'CONTENT_UPDATE',
+        opportunityId: otherOpportunityId,
+      });
+
+      requestContext.data = [{
+        type: 'CONTENT_UPDATE',
+        opportunityId,
+        suggestionIds: [foreignSuggestion.getId()],
+      }];
+
+      const response = await fixesController.createFixes(requestContext);
+      const { fixes, metadata } = await response.json();
+      expect(metadata).deep.equals({ total: 1, success: 0, failed: 1 });
+      expect(fixes[0]).includes({ index: 0, statusCode: 400, message: 'Invalid suggestion IDs' });
+      expect(fixEntityCollection.setSuggestionsForFixEntity).to.not.have.been.called;
+    });
+
+    it('marks linked suggestions FIXED atomically when suggestionsTargetStatus is set', async () => {
+      const suggestions = await Promise.all([
+        createSuggestion({ type: 'CONTENT_UPDATE' }),
+        createSuggestion({ type: 'CONTENT_UPDATE' }),
+      ]);
+
+      requestContext.data = [{
+        type: 'CONTENT_UPDATE',
+        opportunityId,
+        suggestionIds: suggestions.map((s) => s.getId()),
+        suggestionsTargetStatus: Suggestion.STATUSES.FIXED,
+      }];
+
+      fixEntityCollection.setSuggestionsForFixEntity.resolves({
+        createdItems: suggestions.map((s) => ({
+          getSuggestionId: () => s.getId(),
+          getFixEntityId: () => 'mock-fix-id',
+        })),
+        errorItems: [],
+        removedCount: 0,
+      });
+      suggestionCollection.bulkUpdateStatus.resolves(suggestions);
+
+      const response = await fixesController.createFixes(requestContext);
+      expect(response).includes({ status: 207 });
+
+      const { fixes, metadata } = await response.json();
+      expect(metadata).deep.equals({ total: 1, success: 1, failed: 0 });
+      expect(fixes[0]).includes({ index: 0, statusCode: 201 });
+
+      expect(suggestionCollection.bulkUpdateStatus).to.have.been.calledOnceWith(
+        suggestions,
+        Suggestion.STATUSES.FIXED,
+      );
+      // The fix must be created/linked before suggestions are marked fixed.
+      expect(fixEntityCollection.setSuggestionsForFixEntity).to.have.been.calledBefore(
+        suggestionCollection.bulkUpdateStatus,
+      );
+    });
+
+    it('does not mark suggestions FIXED when suggestionsTargetStatus is absent', async () => {
+      const suggestion = await createSuggestion({ type: 'CONTENT_UPDATE' });
+
+      requestContext.data = [{
+        type: 'CONTENT_UPDATE',
+        opportunityId,
+        suggestionIds: [suggestion.getId()],
+      }];
+
+      fixEntityCollection.setSuggestionsForFixEntity.resolves({
+        createdItems: [{
+          getSuggestionId: () => suggestion.getId(),
+          getFixEntityId: () => 'mock-fix-id',
+        }],
+        errorItems: [],
+        removedCount: 0,
+      });
+
+      const response = await fixesController.createFixes(requestContext);
+      expect(response).includes({ status: 207 });
+      expect(suggestionCollection.bulkUpdateStatus).to.not.have.been.called;
     });
 
     describe('document path enrichment (AEM CS and AEM Edge)', () => {
@@ -2504,6 +2586,63 @@ describe('Fixes Controller', () => {
       });
 
       expect(fix.patcher.save).calledOnce;
+    });
+
+    it('marks linked suggestions FIXED when suggestionsTargetStatus is set and status becomes DEPLOYED', async () => {
+      const fixId = 'a4a6055c-de4b-4552-bc0c-01fdb45b98d5';
+      await createFix(fixId);
+      const suggestion = await suggestionCollection.create({
+        opportunityId, type: 'CONTENT_UPDATE', status: 'PENDING',
+      });
+      fixEntityCollection.getSuggestionsByFixEntityId.withArgs(fixId).resolves([suggestion]);
+      suggestionCollection.bulkUpdateStatus.resolves([suggestion]);
+
+      requestContext.data = [{
+        id: fixId, status: 'DEPLOYED', suggestionsTargetStatus: Suggestion.STATUSES.FIXED,
+      }];
+
+      const response = await fixesController.patchFixesStatus(requestContext);
+      expect(response).includes({ status: 207 });
+      const { fixes, metadata } = await response.json();
+      expect(metadata).deep.equals({ total: 1, success: 1, failed: 0 });
+      expect(fixes[0]).includes({ index: 0, statusCode: 200 });
+
+      expect(suggestionCollection.bulkUpdateStatus).to.have.been.calledOnceWith(
+        [suggestion],
+        Suggestion.STATUSES.FIXED,
+      );
+    });
+
+    it('applies suggestionsTargetStatus regardless of which fix status it transitions to', async () => {
+      const fixId = 'a4a6055c-de4b-4552-bc0c-01fdb45b98d5';
+      await createFix(fixId);
+      const suggestion = await suggestionCollection.create({
+        opportunityId, type: 'CONTENT_UPDATE', status: 'PENDING',
+      });
+      fixEntityCollection.getSuggestionsByFixEntityId.withArgs(fixId).resolves([suggestion]);
+      suggestionCollection.bulkUpdateStatus.resolves([suggestion]);
+
+      requestContext.data = [{
+        id: fixId, status: 'FAILED', suggestionsTargetStatus: Suggestion.STATUSES.SKIPPED,
+      }];
+
+      const response = await fixesController.patchFixesStatus(requestContext);
+      expect(response).includes({ status: 207 });
+      expect(suggestionCollection.bulkUpdateStatus).to.have.been.calledOnceWith(
+        [suggestion],
+        Suggestion.STATUSES.SKIPPED,
+      );
+    });
+
+    it('does not mark suggestions FIXED when suggestionsTargetStatus is absent', async () => {
+      const fixId = 'a4a6055c-de4b-4552-bc0c-01fdb45b98d5';
+      await createFix(fixId);
+
+      requestContext.data = [{ id: fixId, status: 'DEPLOYED' }];
+
+      const response = await fixesController.patchFixesStatus(requestContext);
+      expect(response).includes({ status: 207 });
+      expect(suggestionCollection.bulkUpdateStatus).to.not.have.been.called;
     });
 
     it('can patch the status of multiple fixes', async () => {

--- a/test/controllers/fixes.test.js
+++ b/test/controllers/fixes.test.js
@@ -2022,6 +2022,9 @@ describe('Fixes Controller', () => {
         errorItems: [],
         removedCount: 0,
       });
+      // bulkUpdateStatus mutates and returns the suggestions in the real
+      // collection; simulate that mutation for the stub.
+      suggestions.forEach((s) => s.setStatus(Suggestion.STATUSES.FIXED));
       suggestionCollection.bulkUpdateStatus.resolves(suggestions);
 
       const response = await fixesController.createFixes(requestContext);
@@ -2030,6 +2033,15 @@ describe('Fixes Controller', () => {
       const { fixes, metadata } = await response.json();
       expect(metadata).deep.equals({ total: 1, success: 1, failed: 0 });
       expect(fixes[0]).includes({ index: 0, statusCode: 201 });
+
+      // The response echoes back the updated suggestions so the caller (e.g. the
+      // Success Studio UI) can sync its local state without a separate refetch.
+      expect(fixes[0].suggestions).to.have.lengthOf(2);
+      expect(fixes[0].suggestions.map((s) => s.id)).to.have.members(
+        suggestions.map((s) => s.getId()),
+      );
+      expect(fixes[0].suggestions.every((s) => s.status === Suggestion.STATUSES.FIXED))
+        .to.be.true;
 
       expect(suggestionCollection.bulkUpdateStatus).to.have.been.calledOnceWith(
         suggestions,
@@ -2062,6 +2074,10 @@ describe('Fixes Controller', () => {
       const response = await fixesController.createFixes(requestContext);
       expect(response).includes({ status: 207 });
       expect(suggestionCollection.bulkUpdateStatus).to.not.have.been.called;
+
+      const { fixes } = await response.json();
+      // No suggestion mutation happened, so the response carries no suggestions field.
+      expect(fixes[0].suggestions).to.be.undefined;
     });
 
     describe('document path enrichment (AEM CS and AEM Edge)', () => {
@@ -2595,6 +2611,9 @@ describe('Fixes Controller', () => {
         opportunityId, type: 'CONTENT_UPDATE', status: 'PENDING',
       });
       fixEntityCollection.getSuggestionsByFixEntityId.withArgs(fixId).resolves([suggestion]);
+      // bulkUpdateStatus mutates and returns the suggestion in the real
+      // collection; simulate that mutation for the stub.
+      suggestion.setStatus(Suggestion.STATUSES.FIXED);
       suggestionCollection.bulkUpdateStatus.resolves([suggestion]);
 
       requestContext.data = [{
@@ -2606,6 +2625,14 @@ describe('Fixes Controller', () => {
       const { fixes, metadata } = await response.json();
       expect(metadata).deep.equals({ total: 1, success: 1, failed: 0 });
       expect(fixes[0]).includes({ index: 0, statusCode: 200 });
+
+      // The response echoes back the updated suggestion so the caller can sync its
+      // local state without a separate refetch.
+      expect(fixes[0].suggestions).to.have.lengthOf(1);
+      expect(fixes[0].suggestions[0]).to.include({
+        id: suggestion.getId(),
+        status: Suggestion.STATUSES.FIXED,
+      });
 
       expect(suggestionCollection.bulkUpdateStatus).to.have.been.calledOnceWith(
         [suggestion],
@@ -2643,6 +2670,9 @@ describe('Fixes Controller', () => {
       const response = await fixesController.patchFixesStatus(requestContext);
       expect(response).includes({ status: 207 });
       expect(suggestionCollection.bulkUpdateStatus).to.not.have.been.called;
+
+      const { fixes } = await response.json();
+      expect(fixes[0].suggestions).to.be.undefined;
     });
 
     it('can patch the status of multiple fixes', async () => {

--- a/test/controllers/suggestions.test.js
+++ b/test/controllers/suggestions.test.js
@@ -5162,6 +5162,80 @@ describe('Suggestions Controller', () => {
     });
   });
 
+  describe('FIXED requires a Fix entity for gated opportunity types', () => {
+    const patchToFixed = async (opportunityType, endpointName) => {
+      const suggestionEntity = mockSuggestionEntity({
+        id: SUGGESTION_IDS[0],
+        opportunityId: OPPORTUNITY_ID,
+        type: 'CODE_CHANGE',
+        status: 'IN_PROGRESS',
+        rank: 1,
+        data: { info: 'sample data' },
+      }, removeStub);
+      const saveSpy = sandbox.spy(suggestionEntity, 'save');
+      suggestionEntity.getOpportunity = () => ({
+        getSiteId: () => SITE_ID,
+        getType: () => opportunityType,
+      });
+
+      mockSuggestion.findById.withArgs(SUGGESTION_IDS[0]).resolves(suggestionEntity);
+      mockSite.findById.withArgs(SITE_ID).resolves(site);
+      sandbox.stub(AccessControlUtil.prototype, 'hasAccess').resolves(true);
+      sandbox.stub(AccessControlUtil.prototype, 'hasS2SCapability').resolves({ allowed: false, reason: 'not-s2s' });
+      sandbox.stub(AccessControlUtil.prototype, 'hasAdminAccess').returns(true);
+
+      const response = endpointName === 'patchSuggestion'
+        ? await suggestionsController.patchSuggestion({
+          params: {
+            siteId: SITE_ID, opportunityId: OPPORTUNITY_ID, suggestionId: SUGGESTION_IDS[0],
+          },
+          data: { status: 'FIXED' },
+          ...context,
+        })
+        : await suggestionsController.patchSuggestionsStatus({
+          params: { siteId: SITE_ID, opportunityId: OPPORTUNITY_ID },
+          data: [{ id: SUGGESTION_IDS[0], status: 'FIXED' }],
+          ...context,
+        });
+      return { response, saveSpy };
+    };
+
+    it('patchSuggestion rejects direct FIXED transition for a gated type (alt-text)', async () => {
+      const { response, saveSpy } = await patchToFixed('alt-text', 'patchSuggestion');
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      expect(body.message).to.match(/cannot be marked FIXED directly/);
+      expect(body.message).to.include('alt-text');
+      expect(saveSpy).to.not.have.been.called;
+    });
+
+    it('patchSuggestion allows direct FIXED transition for a non-gated type', async () => {
+      const { response, saveSpy } = await patchToFixed('test-opportunity-type', 'patchSuggestion');
+      expect(response.status).to.equal(200);
+      expect(saveSpy).to.have.been.calledOnce;
+    });
+
+    it('patchSuggestionsStatus rejects direct FIXED transition for a gated type (broken-backlinks)', async () => {
+      const { response, saveSpy } = await patchToFixed('broken-backlinks', 'patchSuggestionsStatus');
+      expect(response.status).to.equal(207);
+      const body = await response.json();
+      expect(body.suggestions[0]).to.have.property('statusCode', 400);
+      expect(body.suggestions[0].message).to.match(/cannot be marked FIXED directly/);
+      expect(body.suggestions[0].message).to.include('broken-backlinks');
+      expect(body.metadata).to.have.property('failed', 1);
+      expect(saveSpy).to.not.have.been.called;
+    });
+
+    it('patchSuggestionsStatus allows direct FIXED transition for a non-gated type', async () => {
+      const { response, saveSpy } = await patchToFixed('test-opportunity-type', 'patchSuggestionsStatus');
+      expect(response.status).to.equal(207);
+      const body = await response.json();
+      expect(body.suggestions[0]).to.have.property('statusCode', 200);
+      expect(body.metadata).to.have.property('success', 1);
+      expect(saveSpy).to.have.been.calledOnce;
+    });
+  });
+
   describe('auto-fix suggestions', () => {
     let suggestionsControllerWithMock;
     beforeEach(async () => {

--- a/test/utils/suggestion-fix-required-types.test.js
+++ b/test/utils/suggestion-fix-required-types.test.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { SUGGESTION_TYPES_REQUIRING_FIX_ENTITY } from '../../src/utils/suggestion-fix-required-types.js';
+
+describe('SUGGESTION_TYPES_REQUIRING_FIX_ENTITY', () => {
+  it('is a non-empty array of unique strings', () => {
+    expect(SUGGESTION_TYPES_REQUIRING_FIX_ENTITY).to.be.an('array').that.is.not.empty;
+    expect(new Set(SUGGESTION_TYPES_REQUIRING_FIX_ENTITY).size)
+      .to.equal(SUGGESTION_TYPES_REQUIRING_FIX_ENTITY.length);
+    SUGGESTION_TYPES_REQUIRING_FIX_ENTITY.forEach((type) => {
+      expect(type).to.be.a('string').that.is.not.empty;
+    });
+  });
+
+  it('includes the reported opportunity types (alt-text, broken-backlinks)', () => {
+    expect(SUGGESTION_TYPES_REQUIRING_FIX_ENTITY).to.include('alt-text');
+    expect(SUGGESTION_TYPES_REQUIRING_FIX_ENTITY).to.include('broken-backlinks');
+  });
+
+  it('excludes generic-opportunity (shared fallback type used by unrelated flows)', () => {
+    expect(SUGGESTION_TYPES_REQUIRING_FIX_ENTITY).to.not.include('generic-opportunity');
+  });
+});


### PR DESCRIPTION
## Problem

Engineers are able to manually change a Suggestion's status to FIXED via the public
API without ever creating a Fix entity for it. `patchSuggestion` (single) and
`patchSuggestionsStatus` (bulk) accept `status: FIXED` directly, with no check that a
corresponding Fix exists. The only guards in place today — a generic status-transition
table (default `warn`, not `enforce`) and an admin gate scoped to `REJECTED` — don't
know or care whether a Fix backs the transition. Nowhere in this repo's
suggestion-status code paths is `Fix.create` even called; fix creation and suggestion
status updates are entirely disjoint operations today.

We want to block this — but **only for the opportunity types where a Fix entity is
actually expected to exist** before a suggestion can be FIXED. Not every opportunity
type has a code path that produces a Fix (e.g. purely metric-derived resolutions), so
a blanket block would be wrong; it needs to be scoped to the types where "FIXED
without a Fix" is actually a data-integrity violation.

Jira: https://jira.corp.adobe.com/browse/SITES-50648

## Constraint: fix this at the API layer, not the data-access layer

The obvious place to enforce "FIXED requires a Fix" as a hard invariant is the
data-access layer (`@adobe/spacecat-shared-data-access`, in `Suggestion.setStatus`)
— that's the one chokepoint every writer passes through. But that same data-access
layer is also used directly by the autofix worker (and potentially other future
consumers), not just this API. Changing the invariant there means changing behavior
for every consumer at once, in a separate package with its own release cycle, and
would need its own design pass (does the autofix worker's own internal flows always
satisfy the invariant already? does every opportunity type actually need it, or does
the enforcement need an escape hatch?).

We're keeping this change scoped to **this repo's API layer only** — the two public
PATCH endpoints — rather than the shared data-access layer. That means:
- The autofix worker's own internal ordering issues (some handlers create the Fix
  before marking FIXED, some do it in the reverse order with no atomicity) are a
  separate, out-of-scope problem for a different repo.
- The block only applies to requests coming through this API's public routes, not to
  every possible writer of `Suggestion.status`.

## Solution

**1. Block direct client transitions to FIXED, scoped by opportunity type.**
A new constant, `SUGGESTION_TYPES_REQUIRING_FIX_ENTITY`
(`src/utils/suggestion-fix-required-types.js`), lists exactly the opportunity types
where a Fix is expected before FIXED. `patchSuggestion` and `patchSuggestionsStatus`
each check: if the target status is FIXED and the suggestion's opportunity type is in
this list, reject with 400 and point the caller at the fixes endpoint instead. The
check is duplicated in both handlers (they're independent routes, neither delegates
to the other) — following the same pattern already used for the existing
REJECTED-transition check in both. `generic-opportunity` is excluded from the list
since it's a shared fallback type used by several unrelated flows, not one semantic
type — blocking it would over-restrict suggestions that happen to share that
fallback bucket for unrelated reasons.

**2. Give callers a real way to satisfy the requirement: create/update the Fix and
transition the suggestion atomically, in one request.**
`POST .../opportunities/:opportunityId/fixes` (`createFixes`) and
`PATCH .../opportunities/:opportunityId/status` (`patchFixesStatus`) now accept an
optional `suggestionsTargetStatus` field. When present, once the fix write succeeds,
its linked suggestions are transitioned to that status in the same request — so a
suggestion is never transitioned without a fix already persisted behind it. Extending
these existing endpoints (rather than adding a new route) was the natural fit:
`createFixes` already accepted `suggestionIds` and already linked them; cascading a
status change on success is additive to what it already does, and `rollbackFailedFix`
in this same file already sets a precedent for this file touching suggestion status
as a side effect of a fix operation (it sets suggestions to SKIPPED on rollback). A
new route would just duplicate the existing access control, ownership checks, and
dedup logic for no semantic gain.

`suggestionsTargetStatus` takes an actual status value rather than a boolean flag
(e.g. `markSuggestionsFixed: true`), so the contract isn't hardcoded to FIXED and
doesn't need a second flag if some other status ever needs the same atomic guarantee.
Validation of the value itself isn't duplicated in this repo — `bulkUpdateStatus` in
the shared data-access layer already throws on an invalid status, and the existing
error-mapping in both endpoints handles that.

**3. This API is also what Success Studio UI calls for "mark as deployed" — so the
frontend flow needs to change too.**
The UI's `createOpportunityFixes`, `setFixToDeployed`, and `setStatusToDeployedScoped`
flows previously called this same fixes endpoint, then made a **second, separate**
`patchSuggestionStatus` PATCH call to flip the suggestion to FIXED — non-atomic, so a
failure or race between the two calls could leave a suggestion FIXED with no Fix (the
exact bug this PR closes on the API side) or a Fix with no updated suggestion. That
frontend flow is updated in a companion PR (OneAdobe/experience-success-studio-ui#2277)
to pass `suggestionsTargetStatus` on the same request instead of making a second call
— since a customer-facing UI action was itself part of the original problem, it has to
move in lockstep with the API change, not be left calling the old two-step pattern
against a backend that will start rejecting the second step for gated types.

## Test plan

- [x] `npm test` — full suite passing
- [x] `npm run lint` — clean
- [x] `npm run docs:lint` — valid, no new warnings
- [x] New unit tests: the blocklist util, the FIXED-guard on both PATCH endpoints
      (gated vs. non-gated type), `suggestionsTargetStatus` behavior on both fix
      endpoints (atomic success, absent-field no-op, ownership-check regression,
      invalid-suggestion-ID fast-fail without orphaning a Fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
