### PR TITLE
fix(cors): allow If-Match request header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,7 @@ function localCORSWrapper(fn) {
       response.headers.set(
         'Access-Control-Allow-Headers',
         'Content-Type, Authorization, x-api-key, x-ims-org-id, x-client-type, x-import-api-key, '
-        + 'x-trigger-audits, x-requested-with, origin, accept, x-view-as-trial, x-view-full-experience, x-product, x-promise-token, x-promise-audience',
+        + 'x-trigger-audits, x-requested-with, origin, accept, x-view-as-trial, x-view-full-experience, x-product, x-promise-token, x-promise-audience, if-match',
       );
       response.headers.set('Access-Control-Max-Age', '86400');
     }
@@ -229,7 +229,7 @@ async function run(request, context) {
   if (method === 'OPTIONS') {
     return noContent({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-view-full-experience, x-promise-token, x-promise-audience',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-view-full-experience, x-promise-token, x-promise-audience, if-match',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -332,7 +332,7 @@ describe('Index Tests', () => {
     expect(resp.status).to.equal(204);
     expect(resp.headers.plain()).to.eql({
       'access-control-allow-methods': 'GET, HEAD, PATCH, POST, OPTIONS, DELETE',
-      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-view-full-experience, x-promise-token, x-promise-audience',
+      'access-control-allow-headers': 'x-api-key, authorization, origin, x-requested-with, content-type, accept, x-import-api-key, x-client-type, x-trigger-audits, x-view-as-trial, x-view-full-experience, x-promise-token, x-promise-audience, if-match',
       'access-control-max-age': '86400',
       'access-control-allow-origin': '*',
       'content-type': 'application/json; charset=utf-8',


### PR DESCRIPTION
## Summary

- add the standard `If-Match` request header to the deployed API CORS preflight allow-list
- keep the local-development CORS wrapper in parity
- update the exact preflight response regression test

## Context

PR #3218 introduced revision-guarded Serenity tag deletion using `If-Match`. Browsers currently fail the CORS preflight before the request reaches the handler because this header is absent from the API allow-list.

Companion infrastructure PR adobe/spacecat-infrastructure#788 updates the Fastly edge allow-list, which overrides the Lambda response for `/api/*` traffic.

## Validation

- `npx mocha test/index.test.js` — 27 passing
- `npm run lint -- --quiet`
- pre-commit docs validation and strict/base type checks passed

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: []
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```