### PR TITLE
fix: refresh taxonomy before bulk tag validation

### DIFF
--- a/src/support/serenity/handlers/bulk-tags-job.js
+++ b/src/support/serenity/handlers/bulk-tags-job.js
@@ -382,7 +382,15 @@ async function acceptParsedBulkTags({
       await existing.remove();
     }
   }
-  const snapshot = await readTagTreeSnapshot(transport, workspaceId, projectId, log);
+  // A create-tag request may have landed on another Lambda container moments
+  // earlier. Never validate a mutation against this container's cached taxonomy.
+  const snapshot = await readTagTreeSnapshot(
+    transport,
+    workspaceId,
+    projectId,
+    log,
+    { forceRefresh: true },
+  );
   /** @type {TagTreeItem[]} */
   const selected = [];
   for (const id of parsed.tagIds) {

--- a/test/support/serenity/handlers/bulk-tags-job.test.js
+++ b/test/support/serenity/handlers/bulk-tags-job.test.js
@@ -345,6 +345,65 @@ describe('acceptBulkTags idempotency', () => {
   });
 });
 
+describe('acceptBulkTags taxonomy freshness', () => {
+  it('bypasses a cached snapshot when validating a newly created mutation tag', async () => {
+    let familyExists = false;
+    const transport = {
+      listProjectTags: sinon.stub().callsFake((_, __, options = {}) => {
+        let items = [{ id: 'tag-root', name: 'tag', children_count: familyExists ? 1 : 0 }];
+        if (options.parentId === 'tag-root') {
+          items = familyExists ? [{
+            id: 'family',
+            name: 'Family',
+            parent_id: 'tag-root',
+            children_count: 0,
+            path: [{ id: 'tag-root', name: 'tag' }],
+          }] : [];
+        }
+        return Promise.resolve({ items });
+      }),
+    };
+    await readTagTreeSnapshot(transport, 'ws', 'project', {});
+    familyExists = true;
+
+    const job = {
+      getId: () => 'bulk-job',
+      getStatus: () => 'IN_PROGRESS',
+    };
+    const create = sinon.stub().resolves(job);
+    const sendMessage = sinon.stub().resolves();
+    const response = await acceptBulkTags({
+      context: {
+        dataAccess: { AsyncJob: { create } },
+        sqs: { sendMessage },
+        env: { SERENITY_JOB_RUNNER_QUEUE_URL: 'queue-url' },
+        log: { error: sinon.stub(), warn: sinon.stub() },
+      },
+      transport,
+      brandId: 'brand',
+      orgId: 'org',
+      workspaceId: 'ws',
+      projectId: 'project',
+      body: {
+        geoTargetId: 1,
+        languageCode: 'en',
+        operation: 'assign',
+        tagIds: ['family'],
+        filter: { tagFilterMode: 'faceted-v1' },
+      },
+      callerId: 'caller',
+      log: {},
+      promiseToken: FORWARDED_PROMISE_TOKEN,
+      promisePair: SEMRUSH_PROMISE_PAIR,
+    });
+
+    expect(response.status).to.equal(202);
+    expect(transport.listProjectTags).to.have.callCount(3);
+    expect(create).to.have.been.calledOnce;
+    expect(sendMessage).to.have.been.calledOnce;
+  });
+});
+
 describe('bulk tags promise credential forwarding', () => {
   const body = {
     geoTargetId: 1,


### PR DESCRIPTION
## Summary
- force-refresh the acceptance-time tag-tree snapshot for bulk tag mutations
- prevent a newly created tag from being rejected by another Lambda container's cached 5-second snapshot
- add regression coverage that seeds a stale snapshot before acceptance

## Production evidence
The post-#3214 synthetic E2E crossed async authentication and job execution, then a subsequent run reproduced `400 One or more mutation tagIds are unknown in this project` immediately after creating the mutation tag. The existing cache explicitly permits peer-container staleness for five seconds; acceptance validation must not use that cache.

## Validation
- 31 bulk-tags handler tests passing
- 357 affected Serenity/OpenAPI tests passing
- scoped ESLint passing
- base and strict type checks passing

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: []
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```