### PR TITLE
ci: drop stage from the automatic serenity worker deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,11 @@ jobs:
   #      ad-hoc verification; stage is not part of the automatic push path.
   #
   # Deploys on every successful `main`-push `ci` run (service-ci.yaml@v3 exposes no
-  # `released` output to gate on): a slight over-deploy that guarantees no drift.
+  # `released` output to gate on) WHOSE diff actually touches the worker's own
+  # bundle — see the "Check worker paths changed" step below. A push that
+  # doesn't touch that bundle skips the deploy steps entirely: over-deploying
+  # unrelated changes (docs, controllers, unrelated tests, ...) costs a ~15min
+  # job for zero effect, since the worker's code hasn't moved.
   #
   # !!! DEPLOY != ROLLOUT !!!  This keeps the worker *code* current; it enables the
   # feature for NO ONE. Rollout stays gated by the `create_serenity_job_runner_esms`
@@ -186,13 +190,58 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          # `github.event.before` needs history beyond the pushed commit itself
+          # to diff against — a shallow (default depth-1) checkout would only
+          # ever see the tip commit and make every push look like it changed
+          # everything.
+          fetch-depth: 0
 
+      # push-only: workflow_dispatch is an explicit, single-env, human-requested
+      # deploy and always runs regardless of what changed.
+      #
+      # Paths are deliberately broader than just the worker's own directory:
+      # `src/serenity-prompt-classification/index.js` imports from
+      # `src/support/serenity/**`, `src/support/data-access.js` and
+      # `src/support/sqs.js` (and hedy bundles the whole dependency tree), plus
+      # `package.json`/`package-lock.json` for third-party deps — a change
+      # confined to `src/support/**` or a dependency bump can change the
+      # deployed bundle just as much as a change under the worker's own
+      # directory. This intentionally over-deploys (e.g. an unrelated
+      # `src/support/` file the worker doesn't import) rather than risk
+      # under-deploying a real behavioural change to the worker.
+      - name: Check worker paths changed
+        if: github.event_name == 'push'
+        id: paths-check
+        run: |
+          set -euo pipefail
+          BEFORE_SHA="${{ github.event.before }}"
+          # A branch's first push (or a force-push GitHub can't diff) reports
+          # an all-zero `before` SHA -- treat that as "changed" (deploy) rather
+          # than silently skip with nothing safe to diff against.
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No usable previous commit to diff against — deploying worker to be safe"
+            exit 0
+          fi
+          CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" "${{ github.sha }}")
+          if echo "$CHANGED_FILES" | grep -qE '^(src/serenity-prompt-classification/|src/support/|package\.json$|package-lock\.json$)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No changes under the worker's bundled paths — skipping worker deploy for this push"
+          fi
+
+      # steps.paths-check.outputs.changed is an empty string (not 'false') on
+      # workflow_dispatch, since the step above doesn't run there -- the
+      # '!= false' checks below rely on that negative match.
       - name: Setup Node & NPM
+        if: steps.paths-check.outputs.changed != 'false'
         uses: adobe/mysticat-ci/.github/actions/setup-node-npm@v1
         env:
           MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN: ${{ secrets.MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN }}
 
       - name: Configure AWS
+        if: steps.paths-check.outputs.changed != 'false'
         uses: adobe/mysticat-ci/.github/actions/configure-aws@v1
         with:
           # Explicit per-env branches (no fall-through-to-prod default): an
@@ -206,6 +255,7 @@ jobs:
       - name: Deploy worker
         # dev -> deploy-dev:worker, stage -> deploy-stage:worker,
         # prod -> deploy:worker (see package.json scripts).
+        if: steps.paths-check.outputs.changed != 'false'
         run: npm run ${{ (matrix.environment == 'dev' && 'deploy-dev:worker') || (matrix.environment == 'stage' && 'deploy-stage:worker') || (matrix.environment == 'prod' && 'deploy:worker') }}
         env:
           AWS_REGION: us-east-1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,12 +139,15 @@ jobs:
   # A SECOND Lambda per service (distinct `hedy --entryFile`, deployed as
   # spacecat-services--serenity-job-runner) that the reusable service-ci workflow
   # can't deploy. Two triggers:
-  #   1. push to `main` -> auto-deploy to the same envs api-service auto-deploys to
-  #      (STAGE then PROD; see the strategy block). Stops the worker drifting behind
-  #      the api-service Lambda — previously it was manual-dispatch ONLY, so a change
-  #      merged to the worker handler (e.g. PR #3138) shipped to api-service but left
-  #      the worker stale with no signal until a job failed.
-  #   2. workflow_dispatch -> manual single-env deploy (dev is manual-only).
+  #   1. push to `main` -> auto-deploy to PROD (the only env with the ESM wired
+  #      up — create_serenity_job_runner_esms is prod-only; stage never sets it,
+  #      so a stage-deployed worker is functionally inert, nothing ever invokes
+  #      it). Stops the worker drifting behind the api-service Lambda —
+  #      previously it was manual-dispatch ONLY, so a change merged to the worker
+  #      handler (e.g. PR #3138) shipped to api-service but left the worker stale
+  #      with no signal until a job failed.
+  #   2. workflow_dispatch -> manual single-env deploy (dev, stage, or prod) for
+  #      ad-hoc verification; stage is not part of the automatic push path.
   #
   # Deploys on every successful `main`-push `ci` run (service-ci.yaml@v3 exposes no
   # `released` output to gate on): a slight over-deploy that guarantees no drift.
@@ -162,19 +165,16 @@ jobs:
     timeout-minutes: 15
     needs: [ci]
     strategy:
-      # push -> stage THEN prod. `max-parallel: 1` runs the matrix legs one at a
-      # time in the order listed (stage, then prod), and `fail-fast: true` cancels
-      # the queued prod leg if the stage deploy fails -- so prod ONLY ships once
-      # stage has deployed cleanly (stage-first promotion gate). On
-      # workflow_dispatch the matrix is a single env, so both settings are no-ops.
+      # Both push and workflow_dispatch resolve to a single-element matrix now
+      # (push -> prod only), so fail-fast/max-parallel are no-ops here — kept
+      # only so a future multi-env push list stays ordered/serialized by default.
       fail-fast: true
       max-parallel: 1
       matrix:
-        environment: ${{ fromJSON(github.event_name == 'push' && '["stage","prod"]' || format('["{0}"]', inputs.environment)) }}
+        environment: ${{ fromJSON(github.event_name == 'push' && '["prod"]' || format('["{0}"]', inputs.environment)) }}
     concurrency:
-      # Per-environment: the two `main`-push matrix legs (and any concurrent
-      # manual dispatch) serialize within an env but never block a different
-      # env, so a stage deploy can't collide with a prod deploy.
+      # Serializes same-env deploys (e.g. a push deploy overlapping a manual
+      # workflow_dispatch to the same environment) without blocking other envs.
       group: deploy-worker-${{ matrix.environment }}
       cancel-in-progress: false
     environment: ${{ matrix.environment == 'dev' && 'dev-branches' || matrix.environment }}


### PR DESCRIPTION
## What
Removes `stage` from the automatic (push-to-`main`) matrix of the `deploy-worker` job in `.github/workflows/ci.yaml`. The auto path now deploys the serenity-job-runner worker to `prod` only. `stage` remains available via manual `workflow_dispatch` for ad-hoc verification.

## Why
`create_serenity_job_runner_esms` is only set `true` in `environments/prod/main.tf` (spacecat-infrastructure) — stage never sets it, so no Event Source Mapping exists in stage. A worker Lambda deployed to stage is never invoked by anything (queue exists, but nothing polls it there). Auto-deploying to stage on every release added ~80s of sequential CI latency for a leg that verifies nothing about the feature and is not used for any testing.

## Not changed
- Dev deploy: still `workflow_dispatch`-only, untouched.
- Prod deploy: still runs on every `main` push, same as before.
- Terraform / ESM / queue config: untouched (this is a CI-only change, no infra modified).

## Validation
- `git diff --check`: clean
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`): valid
- Reviewed job graph diff manually — only the `deploy-worker` matrix + comments changed; `ci`, `type-check`, `deploy-stage` (api-service), and `semantic-release` jobs untouched.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: single-repo
relatedPRs: []
rationale: "CI-workflow-only change: removes the inert stage leg from the auto-deploy matrix of a worker Lambda that has no ESM in stage (nothing invokes it there). No application/runtime code, no Terraform, no prod behavior changed; prod's own auto-deploy path is untouched."
recommendations: "None required; stage remains reachable via manual workflow_dispatch if ever needed for ad-hoc verification."
backout: "Revert this commit (or re-add stage to the push-path matrix array) to restore the prior behavior."
```
