### PR TITLE
fix: stamp updated_by on bulk tag edits and background reclassification

### DIFF
--- a/src/support/serenity/handlers/bulk-tags-job.js
+++ b/src/support/serenity/handlers/bulk-tags-job.js
@@ -21,6 +21,7 @@ import { readTagTreeSnapshot, incompatibleTaxonomyError } from '../tag-tree.js';
 import { createAndEnqueueJob, retryableJobError } from '../async-job-runner.js';
 import {
   assertPromptTagLimit,
+  buildUpdateMetadata,
   BULK_CREATE_CONCURRENCY,
   listAllProjectPrompts,
   mapLimit,
@@ -437,6 +438,11 @@ async function acceptParsedBulkTags({
         operation: parsed.operation,
         tagIds: parsed.tagIds,
         normalizedFilter,
+        // Authorship (LLMO-6289 follow-up): capture the caller id at enqueue time
+        // so the worker can stamp updated_by on every prompt it touches, instead
+        // of leaving the tag-only mutation attributed to whoever last edited the
+        // prompt through a different path.
+        callerId,
         ...(key ? {
           requestHash: hash,
           idempotencyExpiresAt: now + BULK_IDEMPOTENCY_TTL_SECONDS * 1000,
@@ -617,6 +623,10 @@ export async function handleBulkTagsSubworkspace(
  */
 export async function bulkTagsHandler(context, job, accessToken, injectedTransport) {
   const metadata = job.getMetadata() ?? {};
+  // Authorship (LLMO-6289 follow-up): the caller id captured at enqueue time —
+  // jobs enqueued before this field existed default to 'unknown' rather than
+  // crashing the worker.
+  const { callerId = 'unknown' } = metadata;
   const transport = injectedTransport
     ?? createSerenityTransport({ env: context.env, imsToken: accessToken });
   if (metadata.publishRecoveryPending === true) {
@@ -717,7 +727,7 @@ export async function bulkTagsHandler(context, job, accessToken, injectedTranspo
         references: next,
         replace: true,
       }]);
-      return { updated: true };
+      return { updated: true, semrushPromptId: promptId };
     } catch (error) {
       return {
         failure: {
@@ -734,11 +744,34 @@ export async function bulkTagsHandler(context, job, accessToken, injectedTranspo
     }
   });
   const failures = outcomes.filter((outcome) => outcome.failure).map((outcome) => outcome.failure);
-  const updatedCount = outcomes.filter((outcome) => outcome.updated).length;
+  const updated = outcomes.filter((outcome) => outcome.updated);
+  const updatedCount = updated.length;
   const unchangedCount = outcomes.filter((outcome) => outcome.unchanged).length;
 
   if (updatedCount > 0) {
     invalidateTagCacheForProject(metadata.workspaceId, metadata.projectId);
+    // Best-effort authorship stamp, same order-of-operations as the sync edit
+    // path's applyUpsertTagWrites: the tag write above is the point of the
+    // operation, so a failed stamp here is logged rather than fatal — it must
+    // never discard tag changes the caller already got a successful response
+    // for.
+    try {
+      await transport.patchPromptsMetadataBatch(
+        metadata.workspaceId,
+        metadata.projectId,
+        updated.map((outcome) => ({
+          promptId: outcome.semrushPromptId,
+          metadata: buildUpdateMetadata(callerId),
+        })),
+      );
+    } catch (e) {
+      context.log?.warn?.('serenity bulk tags: tags updated but the authorship stamp failed — Last modified is stale', {
+        workspaceId: metadata.workspaceId,
+        projectId: metadata.projectId,
+        count: updatedCount,
+        error: e?.message,
+      });
+    }
   }
   /** @type {{
    *   state: 'SKIPPED' | 'SUCCEEDED' | 'FAILED',

--- a/src/support/serenity/handlers/classify-prompts-job.js
+++ b/src/support/serenity/handlers/classify-prompts-job.js
@@ -22,6 +22,7 @@ import { invalidateTagCacheForProject } from './markets.js';
 import {
   normalizePromptInput,
   createOnePrompt,
+  buildUpdateMetadata,
   makePromptTagInjector,
   makeIntentInjector,
   mapLimit,
@@ -102,10 +103,15 @@ export async function buildPromptTypeClassifier(dataAccess, brandId) {
  *   carries the promise token and the current requeue depth).
  * @param {string} semrushWorkspaceId
  * @param {Array<{ projectId: string, promptId: string, text: string, tagIds: string[] }>} items
+ * @param {string} [callerId] - resolved caller id (see `resolveCallerId`), carried
+ *   forward from whichever mode enqueued this requeue so the eventual authorship
+ *   stamp on the reclassified prompts still reflects the original submitter, not
+ *   the job runner. Defaults to `'unknown'` in {@link reclassifyExisting}, never
+ *   here, so a caller that forgets to thread it fails loud in that one place.
  * @returns {Promise<string|null>} the new job's id, or `null` if there was
  *   nothing to requeue, or the depth cap was reached.
  */
-async function requeuePending(context, job, semrushWorkspaceId, items) {
+async function requeuePending(context, job, semrushWorkspaceId, items, callerId) {
   if (items.length === 0) {
     return null;
   }
@@ -120,7 +126,7 @@ async function requeuePending(context, job, semrushWorkspaceId, items) {
     promiseToken: currentMetadata.promiseToken,
     promisePair: currentMetadata.promisePair,
     metadata: {
-      mode: 'reclassify', semrushWorkspaceId, items, requeueDepth: currentDepth + 1,
+      mode: 'reclassify', semrushWorkspaceId, items, requeueDepth: currentDepth + 1, callerId,
     },
   });
   return newJob.getId();
@@ -294,7 +300,13 @@ async function createAndClassify(context, job, transport, metadata) {
     failed.push({ text: '', status: 502, message: `publish: ${pubErr.message}` });
   }
 
-  const requeuedJobId = await requeuePending(context, job, semrushWorkspaceId, pendingItems);
+  const requeuedJobId = await requeuePending(
+    context,
+    job,
+    semrushWorkspaceId,
+    pendingItems,
+    callerId,
+  );
 
   return {
     created,
@@ -327,7 +339,11 @@ async function createAndClassify(context, job, transport, metadata) {
  */
 async function reclassifyExisting(context, job, transport, metadata) {
   const { env, log } = context;
-  const { semrushWorkspaceId } = metadata;
+  // Authorship (LLMO-6289 follow-up): carried forward from the create-mode job
+  // that requeued this reclassify pass (see requeuePending) — this is the human/
+  // service that submitted the original prompts, not the job runner. Jobs
+  // requeued before this field existed default to 'unknown' rather than crashing.
+  const { semrushWorkspaceId, callerId = 'unknown' } = metadata;
   const items = Array.isArray(metadata.items) ? metadata.items : [];
 
   const intentByText = await classifyPromptIntentsUnbounded(
@@ -381,6 +397,25 @@ async function reclassifyExisting(context, job, transport, metadata) {
       affectedProjectIds.push(projectId);
     } catch (e) {
       failed.push({ projectId, status: e.status || 500, message: e.message });
+      return;
+    }
+    // Best-effort authorship stamp, same order-of-operations as the sync edit
+    // path's applyUpsertTagWrites: the tag write above is the point of the
+    // operation, so a failed stamp here is logged rather than fatal — it must
+    // never discard tags that were already successfully replaced.
+    try {
+      await transport.patchPromptsMetadataBatch(
+        semrushWorkspaceId,
+        projectId,
+        patchItems.map((item) => ({
+          promptId: item.id,
+          metadata: buildUpdateMetadata(callerId),
+        })),
+      );
+    } catch (e) {
+      log?.warn?.('serenity reclassify: tags replaced but the authorship stamp failed — Last modified is stale', {
+        projectId, count: patchItems.length, error: e?.message,
+      });
     }
   }));
 
@@ -399,7 +434,13 @@ async function reclassifyExisting(context, job, transport, metadata) {
     });
   }
 
-  const requeuedJobId = await requeuePending(context, job, semrushWorkspaceId, stillPending);
+  const requeuedJobId = await requeuePending(
+    context,
+    job,
+    semrushWorkspaceId,
+    stillPending,
+    callerId,
+  );
 
   return {
     patched,

--- a/test/support/serenity/handlers/bulk-tags-job.test.js
+++ b/test/support/serenity/handlers/bulk-tags-job.test.js
@@ -58,6 +58,7 @@ function workerTransport(prompts, update = sinon.stub().resolves(), tree = {}) {
     })),
     listPromptsByTags: sinon.stub().resolves({ items: prompts }),
     updatePromptTagsByIds: update,
+    patchPromptsMetadataBatch: sinon.stub().resolves(),
     publishProject: sinon.stub().resolves(),
   };
 }
@@ -381,6 +382,56 @@ describe('bulkTagsHandler worker accounting', () => {
     expect(transport.updatePromptTagsByIds).to.have.been.calledOnce;
     expect(transport.publishProject).to.have.been.calledOnceWith('ws', 'project');
     expect(result.publish).to.deep.equal({ state: 'SUCCEEDED', error: null });
+  });
+
+  it('stamps authorship metadata on every prompt whose tags were actually updated', async () => {
+    const transport = workerTransport([
+      { id: 'one', tags: [] },
+      { id: 'two', tags: [{ id: 'family' }] },
+    ]);
+    const result = await bulkTagsHandler(
+      { env: {}, log: {} },
+      workerJob(['one', 'two'], { callerId: 'user@example.com' }),
+      'token',
+      transport,
+    );
+
+    expect(result).to.deep.include({ updatedCount: 1, unchangedCount: 1 });
+    expect(transport.patchPromptsMetadataBatch).to.have.been.calledOnce;
+    const [ws, project, items] = transport.patchPromptsMetadataBatch.firstCall.args;
+    expect(ws).to.equal('ws');
+    expect(project).to.equal('project');
+    expect(items).to.have.lengthOf(1);
+    expect(items[0].promptId).to.equal('one');
+    expect(items[0].metadata.updated_by).to.equal('user@example.com');
+  });
+
+  it('defaults the authorship stamp to unknown when the job predates callerId', async () => {
+    const transport = workerTransport([{ id: 'one', tags: [] }]);
+    await bulkTagsHandler({ env: {}, log: {} }, workerJob(['one']), 'token', transport);
+
+    const [, , items] = transport.patchPromptsMetadataBatch.firstCall.args;
+    expect(items[0].metadata.updated_by).to.equal('unknown');
+  });
+
+  it('does not stamp metadata when nothing was updated', async () => {
+    const transport = workerTransport([{ id: 'one', tags: [{ id: 'family' }] }]);
+    await bulkTagsHandler({ env: {}, log: {} }, workerJob(['one']), 'token', transport);
+
+    expect(transport.patchPromptsMetadataBatch).not.to.have.been.called;
+  });
+
+  it('reports success even when the best-effort authorship stamp fails', async () => {
+    const transport = workerTransport([{ id: 'one', tags: [] }]);
+    transport.patchPromptsMetadataBatch.rejects(new Error('upstream metadata write failed'));
+    const warn = sinon.stub();
+
+    const result = await bulkTagsHandler({ env: {}, log: { warn } }, workerJob(['one']), 'token', transport);
+
+    expect(result).to.deep.include({ outcome: 'SUCCEEDED', updatedCount: 1, failureCount: 0 });
+    expect(transport.updatePromptTagsByIds).to.have.been.calledOnce;
+    expect(warn).to.have.been.calledOnce;
+    expect(warn.firstCall.args[0]).to.include('authorship stamp failed');
   });
 
   it('applies the acceptance-normalized facet groups to the worker-time corpus', async () => {

--- a/test/support/serenity/handlers/classify-prompts-job.test.js
+++ b/test/support/serenity/handlers/classify-prompts-job.test.js
@@ -62,6 +62,7 @@ describe('handlers/classify-prompts-job.js (serenity-docs#33)', () => {
       createPromptsWithMetadata: sinon.stub().resolves({ items: [{ id: 'created-prompt' }] }),
       publishProject: sinon.stub().resolves(),
       updatePromptTagsByIds: sinon.stub().resolves(),
+      patchPromptsMetadataBatch: sinon.stub().resolves(),
       // Subworkspace create branch resolves projects from ONE live listing
       // (buildSliceProjectMap) instead of the BrandSemrushProject DB mapping.
       // A single project on the (2840, en) slice: settings echo the draft's real
@@ -192,6 +193,36 @@ describe('handlers/classify-prompts-job.js (serenity-docs#33)', () => {
       // mints a fresh one (the worker has no HTTP context to mint from).
       expect(enqueueArgs.promiseToken).to.deep.equal({ promise_token: 'ptok-current' });
       expect(enqueueArgs.metadata.requeueDepth).to.equal(1);
+      // No callerId on the original job (predates the field) — must default
+      // rather than crash or silently drop to an empty string.
+      expect(enqueueArgs.metadata.callerId).to.equal('unknown');
+    });
+
+    it('carries the original callerId forward onto the reclassify requeue', async () => {
+      const intentByTextMap = new Map([['ambiguous text', null]]);
+      const requeuedJob = { getId: () => 'job-followup' };
+      const createAndEnqueueJobStub = sinon.stub().resolves(requeuedJob);
+      const { classifyPromptsHandler } = await load({
+        intentByTextMap, createAndEnqueueJobStub, transport,
+      });
+
+      const project = { getGeoTargetId: () => 2840, getLanguageCode: () => 'en', getSemrushProjectId: () => 'proj-1' };
+      const context = {
+        env: {}, log: fakeLog(), dataAccess: dataAccessFor([project]),
+      };
+      const job = makeJob({
+        brandId: 'brand-1',
+        semrushWorkspaceId: WORKSPACE,
+        callerId: 'user@example.com',
+        prompts: [{
+          text: 'ambiguous text', geoTargetId: 2840, languageCode: 'en', tagIds: [TAG_IDS.categoryRunningShoes],
+        }],
+      });
+
+      await classifyPromptsHandler(context, job, 'token');
+
+      const [, enqueueArgs] = createAndEnqueueJobStub.firstCall.args;
+      expect(enqueueArgs.metadata.callerId).to.equal('user@example.com');
     });
 
     it('stops requeuing once the depth cap is reached, leaving the rest permanently pending', async () => {
@@ -333,6 +364,104 @@ describe('handlers/classify-prompts-job.js (serenity-docs#33)', () => {
       expect(createAndEnqueueJobStub).to.not.have.been.called;
     });
 
+    it('stamps authorship metadata after successfully patching a project\'s tags', async () => {
+      const intentByTextMap = new Map([['great product', 'Commercial']]);
+      const createAndEnqueueJobStub = sinon.stub();
+      const { classifyPromptsHandler } = await load({
+        intentByTextMap, createAndEnqueueJobStub, transport,
+      });
+
+      const context = {
+        env: {}, log: fakeLog(), dataAccess: dataAccessFor([]),
+      };
+      const job = makeJob({
+        mode: 'reclassify',
+        semrushWorkspaceId: WORKSPACE,
+        callerId: 'user@example.com',
+        items: [{
+          projectId: 'proj-1', promptId: 'prompt-1', text: 'great product', tagIds: [TAG_IDS.categoryRunningShoes],
+        }],
+      });
+
+      await classifyPromptsHandler(context, job, 'token');
+
+      expect(transport.patchPromptsMetadataBatch).to.have.been.calledOnce;
+      const [ws, projectId, items] = transport.patchPromptsMetadataBatch.firstCall.args;
+      expect(ws).to.equal(WORKSPACE);
+      expect(projectId).to.equal('proj-1');
+      expect(items).to.have.lengthOf(1);
+      expect(items[0].promptId).to.equal('prompt-1');
+      expect(items[0].metadata.updated_by).to.equal('user@example.com');
+    });
+
+    it('defaults the authorship stamp to unknown when the job predates callerId', async () => {
+      const intentByTextMap = new Map([['great product', 'Commercial']]);
+      const { classifyPromptsHandler } = await load({
+        intentByTextMap, createAndEnqueueJobStub: sinon.stub(), transport,
+      });
+
+      const context = { env: {}, log: fakeLog(), dataAccess: dataAccessFor([]) };
+      const job = makeJob({
+        mode: 'reclassify',
+        semrushWorkspaceId: WORKSPACE,
+        items: [{
+          projectId: 'proj-1', promptId: 'prompt-1', text: 'great product', tagIds: [TAG_IDS.categoryRunningShoes],
+        }],
+      });
+
+      await classifyPromptsHandler(context, job, 'token');
+
+      const [, , items] = transport.patchPromptsMetadataBatch.firstCall.args;
+      expect(items[0].metadata.updated_by).to.equal('unknown');
+    });
+
+    it('does not stamp metadata for a project whose tag patch failed', async () => {
+      const intentByTextMap = new Map([['great product', 'Commercial']]);
+      transport.updatePromptTagsByIds.rejects(Object.assign(new Error('upstream'), { status: 500 }));
+      const { classifyPromptsHandler } = await load({
+        intentByTextMap, createAndEnqueueJobStub: sinon.stub(), transport,
+      });
+
+      const context = { env: {}, log: fakeLog(), dataAccess: dataAccessFor([]) };
+      const job = makeJob({
+        mode: 'reclassify',
+        semrushWorkspaceId: WORKSPACE,
+        items: [{
+          projectId: 'proj-1', promptId: 'prompt-1', text: 'great product', tagIds: [TAG_IDS.categoryRunningShoes],
+        }],
+      });
+
+      const result = await classifyPromptsHandler(context, job, 'token');
+
+      expect(result.failed).to.have.lengthOf(1);
+      expect(transport.patchPromptsMetadataBatch).not.to.have.been.called;
+    });
+
+    it('reports patched even when the best-effort authorship stamp fails', async () => {
+      const intentByTextMap = new Map([['great product', 'Commercial']]);
+      transport.patchPromptsMetadataBatch.rejects(new Error('upstream metadata write failed'));
+      const log = fakeLog();
+      const { classifyPromptsHandler } = await load({
+        intentByTextMap, createAndEnqueueJobStub: sinon.stub(), transport,
+      });
+
+      const context = { env: {}, log, dataAccess: dataAccessFor([]) };
+      const job = makeJob({
+        mode: 'reclassify',
+        semrushWorkspaceId: WORKSPACE,
+        items: [{
+          projectId: 'proj-1', promptId: 'prompt-1', text: 'great product', tagIds: [TAG_IDS.categoryRunningShoes],
+        }],
+      });
+
+      const result = await classifyPromptsHandler(context, job, 'token');
+
+      expect(result.patched).to.have.lengthOf(1);
+      expect(result.failed).to.have.lengthOf(0);
+      expect(log.warn).to.have.been.calledOnce;
+      expect(log.warn.firstCall.args[0]).to.include('authorship stamp failed');
+    });
+
     it('requeues whatever is still pending after a reclassify attempt, without patching it', async () => {
       const intentByTextMap = new Map([['still ambiguous', null]]);
       const requeuedJob = { getId: () => 'job-followup-2' };
@@ -360,6 +489,9 @@ describe('handlers/classify-prompts-job.js (serenity-docs#33)', () => {
       const [, enqueueArgs] = createAndEnqueueJobStub.firstCall.args;
       expect(enqueueArgs.metadata.mode).to.equal('reclassify');
       expect(enqueueArgs.metadata.items[0].promptId).to.equal('prompt-1');
+      // Self-requeue must keep carrying callerId forward across hops, not just
+      // on the first create -> reclassify handoff.
+      expect(enqueueArgs.metadata.callerId).to.equal('unknown');
     });
   });
 });


### PR DESCRIPTION
## Summary

Two live prompt-tag-mutation paths never stamp `updated_by`/`updated_at`, leaving the field pointing at whoever created the prompt (or `unknown`) even after a real edit:

- **Bulk tag assign/remove** (`bulk-tags-job.js`): `callerId` reached the request handler (`acceptParsedBulkTags`) but was never included in the job metadata sent to `createAndEnqueueJob`. The worker (`bulkTagsHandler`) then mutated tags via `updatePromptTagsByIds` with no authorship-stamping call anywhere.
- **Background reclassification** (`classify-prompts-job.js`, `reclassifyExisting`): same shape — patches a prompt's tags (to inject its resolved `intent` value) via `updatePromptTagsByIds`, no stamp call, and the self-requeue chain (`requeuePending`) didn't carry `callerId` forward either.

Both now thread `callerId` through job metadata and, after a successful tag write, make the same best-effort authorship-stamp call the CSV-import edit path already uses (`buildUpdateMetadata` + `patchPromptsMetadataBatch`, see `applyUpsertTagWrites` in `prompts.js`): the tag write is the point of the operation, so a failed stamp is logged, not fatal — it must never discard tag changes the caller already got a successful response for.

Found while investigating a separate, historical `updated_by` null-count question (pre-brandalf migration prompts — unrelated, one-time gap). These two are a distinct, *live* gap on the edit side.

## Changes

- `src/support/serenity/handlers/bulk-tags-job.js`: enqueue `callerId` in job metadata; worker stamps authorship on every prompt it actually updates.
- `src/support/serenity/handlers/classify-prompts-job.js`: `requeuePending` takes and forwards `callerId`; `reclassifyExisting` reads it (default `'unknown'` for jobs enqueued before this existed), stamps authorship per project after a successful tag patch, and carries `callerId` into any further self-requeue.
- Tests added for both: stamp-on-success, default-to-unknown, no-stamp-when-nothing-changed / when-the-tag-write-failed, and best-effort behavior when the stamp call itself fails.

## Test plan

- [x] `npx eslint` clean on all four changed files
- [x] Targeted suite (`bulk-tags-job.test.js` + `classify-prompts-job.test.js`): 46/46 passing
- [x] Full `npm test` (lint + full suite + coverage thresholds): passing

Introduced by: N/A