### PR TITLE
feat(seo-gap-analysis): add public SEO competitor gap analysis endpoint

### DIFF
--- a/docs/openapi/api.yaml
+++ b/docs/openapi/api.yaml
@@ -287,6 +287,10 @@ paths:
     $ref: './site-detection-api.yaml#/site-detection-jobs'
   /sites/detect/jobs/{jobId}:
     $ref: './site-detection-api.yaml#/site-detection-job-status'
+  /seo-gap-analysis:
+    $ref: './seo-gap-analysis-api.yaml#/seo-gap-analysis-jobs'
+  /seo-gap-analysis/jobs/{jobId}:
+    $ref: './seo-gap-analysis-api.yaml#/seo-gap-analysis-job-status'
   /tools/scrape/jobs:
     $ref: './scrape-api.yaml#/create-scrape-job'
   /tools/scrape/jobs/{jobId}:

--- a/docs/openapi/seo-gap-analysis-api.yaml
+++ b/docs/openapi/seo-gap-analysis-api.yaml
@@ -1,0 +1,148 @@
+seo-gap-analysis-jobs:
+  post:
+    tags:
+      - seo-gap-analysis
+    security:
+      - api_key: [ ]
+      - session_token: [ ]
+    summary: Submit a new SEO/GEO/AEO competitor gap analysis job
+    description: |
+      Runs the given keyword through the SERP, discovers the competitor pages ranking for it
+      (excluding the target URL and any `filterDomains`), scrapes and analyzes each competitor
+      page plus the target for SEO / GEO / AEO signals, and produces a structured gap report of
+      the target versus the competitors. The work runs asynchronously — callers receive 202 with
+      a jobId and must poll GET /seo-gap-analysis/jobs/{jobId} for the report.
+    operationId: createSeoGapAnalysisJob
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              keyword:
+                type: string
+                description: The search keyword to analyze.
+                example: best running shoes
+              targetUrl:
+                type: string
+                format: uri
+                description: The URL being optimized.
+                example: https://mybrand.com/running-shoes
+              filterDomains:
+                type: array
+                description: Bare hostnames to exclude from the SERP (owned/partner/noise). Max 50.
+                items:
+                  type: string
+                example: [mybrand.com, partner.com]
+              currentRanking:
+                type: object
+                description: Optional current performance/ranking context, passed through opaquely.
+                additionalProperties: true
+              locale:
+                type: string
+                description: Optional locale hint for the SERP (e.g. "de", "en_us").
+                example: en_us
+            required:
+              - keyword
+              - targetUrl
+    responses:
+      '202':
+        description: SEO gap analysis job accepted
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                jobId:
+                  type: string
+                  format: uuid
+                status:
+                  type: string
+                createdAt:
+                  type: string
+                  format: date-time
+                pollUrl:
+                  type: string
+                  format: uri
+      '400':
+        description: Invalid request (missing keyword, invalid targetUrl, or invalid filterDomains)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+      '401':
+        $ref: './responses.yaml#/401'
+      '500':
+        $ref: './responses.yaml#/500'
+
+seo-gap-analysis-job-status:
+  parameters:
+    - $ref: './parameters.yaml#/jobId'
+  get:
+    tags:
+      - seo-gap-analysis
+    security:
+      - api_key: [ ]
+      - session_token: [ ]
+    summary: Get SEO gap analysis job status and report
+    description: |
+      Returns the current status and, once completed, the SEO/GEO/AEO gap report for the job.
+      The report contains per-factor diffs of the target versus competitors and a prioritized
+      recommendation list.
+    operationId: getSeoGapAnalysisJobStatus
+    responses:
+      '200':
+        description: Job status and (if available) the gap report
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                jobId:
+                  type: string
+                  format: uuid
+                status:
+                  type: string
+                createdAt:
+                  type: string
+                  format: date-time
+                updatedAt:
+                  type: string
+                  format: date-time
+                result:
+                  type: object
+                  additionalProperties: true
+                  description: The gap report (null until the job completes).
+                error:
+                  type: object
+                  properties:
+                    code:
+                      type: string
+                    message:
+                      type: string
+      '400':
+        description: Invalid jobId format
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+      '401':
+        $ref: './responses.yaml#/401'
+      '404':
+        description: Job not found
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+      '500':
+        $ref: './responses.yaml#/500'

--- a/src/controllers/seo-gap-analysis.js
+++ b/src/controllers/seo-gap-analysis.js
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  hasText,
+  isNonEmptyObject,
+  isValidUrl,
+  isValidUUID,
+} from '@adobe/spacecat-shared-utils';
+import {
+  accepted, badRequest, internalServerError, ok,
+} from '@adobe/spacecat-shared-http-utils';
+import { AsyncJob } from '@adobe/spacecat-shared-data-access';
+import { loadJobScopedToCaller } from '../support/async-job-access.js';
+
+const JOB_TYPE = 'seo-gap-analysis';
+const MAX_FILTER_DOMAINS = 50;
+
+/**
+ * Validates the list of domains to exclude from the SERP.
+ * Each entry must be a bare hostname (no scheme/path/whitespace).
+ */
+function isValidFilterDomains(filterDomains) {
+  if (filterDomains === undefined) {
+    return true;
+  }
+  if (!Array.isArray(filterDomains) || filterDomains.length > MAX_FILTER_DOMAINS) {
+    return false;
+  }
+  return filterDomains.every(
+    (d) => hasText(d) && !/\s/.test(d) && !d.includes('://') && !d.includes('/'),
+  );
+}
+
+/**
+ * Creates a SEO gap analysis controller instance.
+ *
+ * Runs a keyword through the SERP, discovers competitor pages ranking for it, scrapes and
+ * analyzes each for SEO/GEO/AEO signals, and returns a structured gap report of the target
+ * page versus the competitors. The heavy lifting runs asynchronously in the audit worker;
+ * callers always get 202 + jobId and poll the GET endpoint for the terminal result.
+ *
+ * @param {Object} ctx - The context object (dataAccess, sqs).
+ * @param {Object} log - The logger instance.
+ * @param {Object} env - The environment configuration object.
+ * @returns {Object} The controller instance.
+ */
+function SeoGapAnalysisController(ctx, log, env) {
+  if (!isNonEmptyObject(ctx)) {
+    throw new Error('Context required');
+  }
+  const { dataAccess, sqs } = ctx;
+
+  if (!isNonEmptyObject(dataAccess)) {
+    throw new Error('Data access required');
+  }
+  if (!isNonEmptyObject(sqs)) {
+    throw new Error('SQS client required');
+  }
+  if (!isNonEmptyObject(env)) {
+    throw new Error('Environment object required');
+  }
+
+  /**
+   * Creates a new async SEO gap analysis job.
+   *
+   * @param {Object} context - The request context.
+   * @param {Object} context.data - The request body.
+   * @param {string} context.data.keyword - The search keyword to analyze.
+   * @param {string} context.data.targetUrl - The URL being optimized.
+   * @param {string[]} [context.data.filterDomains] - Domains to exclude from the SERP.
+   * @param {Object} [context.data.currentRanking] - Optional current performance context.
+   * @returns {Promise<Object>} 202 Accepted with jobId and pollUrl, or an error response.
+   */
+  const createSeoGapAnalysisJob = async (context) => {
+    if (!hasText(env.AUDIT_JOBS_QUEUE_URL)) {
+      log.error('AUDIT_JOBS_QUEUE_URL is not configured');
+      return internalServerError('Service misconfiguration: AUDIT_JOBS_QUEUE_URL is not set');
+    }
+
+    const { data } = context;
+    if (!isNonEmptyObject(data)) {
+      return badRequest('Invalid request: missing application/json data');
+    }
+
+    const {
+      keyword, targetUrl, filterDomains, currentRanking, locale,
+    } = data;
+
+    if (!hasText(keyword)) {
+      return badRequest('Invalid request: keyword is required');
+    }
+    if (!isValidUrl(targetUrl)) {
+      return badRequest('Invalid request: targetUrl must be a valid URL');
+    }
+    if (!isValidFilterDomains(filterDomains)) {
+      return badRequest('Invalid request: filterDomains must be an array of at most 50 bare hostnames');
+    }
+
+    const isDev = env.AWS_ENV === 'dev';
+
+    try {
+      const job = await dataAccess.AsyncJob.create({
+        status: AsyncJob.Status.IN_PROGRESS,
+        metadata: {
+          payload: {
+            keyword,
+            targetUrl,
+            filterDomains: filterDomains ?? [],
+            currentRanking: currentRanking ?? null,
+            locale: locale ?? null,
+          },
+          jobType: JOB_TYPE,
+          tags: [JOB_TYPE],
+        },
+      });
+
+      try {
+        await sqs.sendMessage(env.AUDIT_JOBS_QUEUE_URL, {
+          type: JOB_TYPE,
+          jobId: job.getId(),
+          keyword,
+          targetUrl,
+          filterDomains: filterDomains ?? [],
+          currentRanking: currentRanking ?? null,
+          locale: locale ?? null,
+        });
+      } catch (sqsError) {
+        log.error(`Failed to send message to SQS for job ${job.getId()}: ${sqsError.message}`);
+        try {
+          await job.remove();
+        } catch (removeErr) {
+          log.error(`Failed to remove orphaned job ${job.getId()}: ${removeErr.message}`);
+        }
+        throw new Error('Failed to send message to SQS', { cause: sqsError });
+      }
+
+      return accepted({
+        jobId: job.getId(),
+        status: job.getStatus(),
+        createdAt: job.getCreatedAt(),
+        pollUrl: `https://spacecat.experiencecloud.live/api/${isDev ? 'ci' : 'v1'}/${JOB_TYPE}/jobs/${job.getId()}`,
+      });
+    } catch (error) {
+      log.error(`Failed to create SEO gap analysis job: ${error.message}`);
+      return internalServerError('Failed to create SEO gap analysis job');
+    }
+  };
+
+  /**
+   * Returns the status and result of a SEO gap analysis job.
+   *
+   * @param {Object} context - The request context.
+   * @param {string} context.params.jobId - The job ID to poll.
+   * @returns {Promise<Object>} Job status and result.
+   */
+  const getSeoGapAnalysisJobStatus = async (context) => {
+    const jobId = context.params?.jobId;
+
+    if (!isValidUUID(jobId)) {
+      log.warn(`Invalid jobId: ${jobId}`);
+      return badRequest('Invalid jobId');
+    }
+
+    try {
+      // Scope the read to a seo-gap-analysis job (jobType allowlist) so this reader cannot be
+      // used to fetch other job types through the shared AsyncJob table.
+      const { job, error: accessError } = await loadJobScopedToCaller(ctx, {
+        jobId,
+        allowedJobTypes: [JOB_TYPE],
+      });
+
+      if (accessError) {
+        return accessError;
+      }
+
+      const rawError = job.getError();
+
+      return ok({
+        jobId: job.getId(),
+        status: job.getStatus(),
+        createdAt: job.getCreatedAt(),
+        updatedAt: job.getUpdatedAt(),
+        result: job.getResult() ?? null,
+        error: rawError ? { code: rawError.code, message: rawError.message } : null,
+      });
+    } catch (error) {
+      log.error(`Failed to get SEO gap analysis job status: ${error.message}`);
+      return internalServerError('Failed to get SEO gap analysis job status');
+    }
+  };
+
+  return {
+    createSeoGapAnalysisJob,
+    getSeoGapAnalysisJobStatus,
+  };
+}
+
+export default SeoGapAnalysisController;

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ import BrandsController from './controllers/brands.js';
 import PreflightController from './controllers/preflight.js';
 import OaeValidationController from './controllers/oae-validation.js';
 import SiteDetectionController from './controllers/site-detection.js';
+import SeoGapAnalysisController from './controllers/seo-gap-analysis.js';
 import DemoController from './controllers/demo.js';
 import ConsentBannerController from './controllers/consentBanner.js';
 import ScrapeController from './controllers/scrape.js';
@@ -261,6 +262,7 @@ async function run(request, context) {
     const preflightController = PreflightController(context, log, context.env);
     const oaeValidationController = OaeValidationController(context, log, context.env);
     const siteDetectionController = SiteDetectionController(context, log, context.env);
+    const seoGapAnalysisController = SeoGapAnalysisController(context, log, context.env);
     const demoController = DemoController(context);
     const consentBannerController = ConsentBannerController(context);
     const scrapeController = ScrapeController(context);
@@ -362,6 +364,7 @@ async function run(request, context) {
       ephemeralRunController,
       autofixChecksController,
       siteDetectionController,
+      seoGapAnalysisController,
       plgOnboardingController,
       drsBpPgAuditController,
       webhooksController,

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -666,6 +666,7 @@ const routeFacsCapabilities = {
       'POST /sites/:siteId/url-store/delete': 'llmo/can_configure',
       'POST /sites/:siteId/user-activities': 'llmo/can_configure',
       'POST /sites/detect/jobs': 'llmo/can_configure',
+      'POST /seo-gap-analysis': 'llmo/can_configure',
       'POST /tools/api-keys': 'llmo/can_configure',
       'POST /tools/import/jobs': 'llmo/can_configure',
       'POST /tools/import/jobs/:jobId/result': 'llmo/can_configure',
@@ -868,6 +869,7 @@ const routeFacsCapabilities = {
       'GET /sites/:siteId/user-activities': 'llmo/can_view',
       'GET /sites/by-base-url/:baseURL': 'llmo/can_view',
       'GET /sites/detect/jobs/:jobId': 'llmo/can_view',
+      'GET /seo-gap-analysis/jobs/:jobId': 'llmo/can_view',
       'GET /tools/api-keys': 'llmo/can_view',
       'GET /tools/import/jobs/:jobId': 'llmo/can_view',
       'GET /tools/import/jobs/:jobId/progress': 'llmo/can_view',
@@ -1032,6 +1034,7 @@ const routeFacsCapabilities = {
       'POST /tools/import/jobs/:jobId/result': 'aso/can_configure',
       'POST /tools/scrape/jobs': 'aso/can_configure',
       'POST /sites/detect/jobs': 'aso/can_configure',
+      'POST /seo-gap-analysis': 'aso/can_configure',
       'POST /consent-banner': 'aso/can_configure',
       'POST /organizations/:organizationId/sites/:siteId/contact-sales-lead': 'aso/can_configure',
       'PATCH /contact-sales-leads/:contactSalesLeadId': 'aso/can_configure',
@@ -1135,6 +1138,7 @@ const routeFacsCapabilities = {
       'POST /sites/:siteId/graph': 'aso/can_view',
       'GET /preflight/jobs/:jobId': 'aso/can_view',
       'GET /sites/detect/jobs/:jobId': 'aso/can_view',
+      'GET /seo-gap-analysis/jobs/:jobId': 'aso/can_view',
 
       // Paid traffic (full surface)
       'GET /sites/:siteId/traffic/paid': 'aso/can_view',

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -98,6 +98,7 @@ function isStaticRoute(routePattern) {
  * @param {Object} ephemeralRunController - The ephemeral run batch controller.
  * @param {Object} autofixChecksController - Autofix checks controller for autofix deploy.
  * @param {Object} siteDetectionController - The site detection controller.
+ * @param {Object} seoGapAnalysisController - The SEO gap analysis controller.
  * @param {Object} plgOnboardingController - The PLG onboarding controller.
  * @param {Object} drsBpPgAuditController - DRS Brand Presence PostgREST audit proxy controller.
  * @param {Object} webhooksController - GitHub webhook handler controller.
@@ -170,6 +171,7 @@ export default function getRouteHandlers(
   ephemeralRunController,
   autofixChecksController,
   siteDetectionController,
+  seoGapAnalysisController,
   plgOnboardingController,
   drsBpPgAuditController,
   webhooksController,
@@ -342,6 +344,8 @@ export default function getRouteHandlers(
     'GET /preflight/jobs/:jobId': preflightController.getPreflightJobStatusAndResult,
     'POST /sites/detect/jobs': siteDetectionController.createSiteDetectionJob,
     'GET /sites/detect/jobs/:jobId': siteDetectionController.getSiteDetectionJobStatus,
+    'POST /seo-gap-analysis': seoGapAnalysisController.createSeoGapAnalysisJob,
+    'GET /seo-gap-analysis/jobs/:jobId': seoGapAnalysisController.getSeoGapAnalysisJobStatus,
     'GET /sites': sitesController.getAll,
     'POST /sites': sitesController.createSite,
     'GET /sites.csv': sitesController.getAllAsCsv,

--- a/src/routes/required-capabilities.js
+++ b/src/routes/required-capabilities.js
@@ -460,6 +460,8 @@ const routeRequiredCapabilities = {
   'POST /sites': CAP_SITE_CREATE,
   'POST /sites/detect/jobs': 'site:write',
   'GET /sites/detect/jobs/:jobId': 'site:read',
+  'POST /seo-gap-analysis': 'site:write',
+  'GET /seo-gap-analysis/jobs/:jobId': 'site:read',
   'GET /sites.csv': 'site:read',
   'GET /sites.xlsx': 'site:read',
   'GET /sites/:siteId': 'site:read',

--- a/test/controllers/seo-gap-analysis.test.js
+++ b/test/controllers/seo-gap-analysis.test.js
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { use, expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import { AsyncJob } from '@adobe/spacecat-shared-data-access';
+
+import SeoGapAnalysisController from '../../src/controllers/seo-gap-analysis.js';
+
+use(sinonChai);
+
+const JOB_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+const TARGET = 'https://mybrand.com/page';
+
+describe('SeoGapAnalysisController', () => {
+  const sandbox = sinon.createSandbox();
+
+  const log = {
+    info: sandbox.stub(), error: sandbox.stub(), warn: sandbox.stub(), debug: sandbox.stub(),
+  };
+
+  const mockJob = {
+    getId: sandbox.stub().returns(JOB_ID),
+    getStatus: sandbox.stub().returns(AsyncJob.Status.IN_PROGRESS),
+    getCreatedAt: sandbox.stub().returns('2026-01-01T00:00:00Z'),
+    getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:01Z'),
+    getResult: sandbox.stub().returns(null),
+    getError: sandbox.stub().returns(null),
+    getMetadata: sandbox.stub().returns({ jobType: 'seo-gap-analysis', payload: {} }),
+    remove: sandbox.stub().resolves(),
+    setStatus: sandbox.stub(),
+    setError: sandbox.stub(),
+    save: sandbox.stub().resolves(),
+  };
+
+  const mockDataAccess = {
+    AsyncJob: { create: sandbox.stub(), findById: sandbox.stub() },
+  };
+  const mockSqs = { sendMessage: sandbox.stub().resolves() };
+  const env = {
+    AUDIT_JOBS_QUEUE_URL: 'https://sqs.us-east-1.amazonaws.com/queue/audit-jobs',
+    AWS_ENV: 'prod',
+  };
+
+  let controller;
+
+  beforeEach(() => {
+    sandbox.resetHistory();
+    mockDataAccess.AsyncJob.create.resolves(mockJob);
+    mockDataAccess.AsyncJob.findById.resolves(mockJob);
+    mockJob.getResult.returns(null);
+    mockJob.getError.returns(null);
+    mockJob.getMetadata.returns({ jobType: 'seo-gap-analysis', payload: {} });
+    mockSqs.sendMessage.resolves();
+    controller = SeoGapAnalysisController({ dataAccess: mockDataAccess, sqs: mockSqs }, log, env);
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('constructor validation', () => {
+    it('throws when context is missing', () => {
+      expect(() => SeoGapAnalysisController(null, log, env)).to.throw('Context required');
+    });
+    it('throws when dataAccess is missing', () => {
+      expect(() => SeoGapAnalysisController({ dataAccess: null, sqs: mockSqs }, log, env))
+        .to.throw('Data access required');
+    });
+    it('throws when sqs is missing', () => {
+      expect(() => SeoGapAnalysisController({ dataAccess: mockDataAccess, sqs: null }, log, env))
+        .to.throw('SQS client required');
+    });
+    it('throws when env is missing', () => {
+      const ctx = { dataAccess: mockDataAccess, sqs: mockSqs };
+      expect(() => SeoGapAnalysisController(ctx, log, null))
+        .to.throw('Environment object required');
+    });
+  });
+
+  describe('createSeoGapAnalysisJob', () => {
+    const validBody = { keyword: 'running shoes', targetUrl: TARGET, filterDomains: ['mybrand.com'] };
+
+    it('returns 500 when the queue URL is not configured', async () => {
+      const ctrl = SeoGapAnalysisController({ dataAccess: mockDataAccess, sqs: mockSqs }, log, { AWS_ENV: 'prod' });
+      const res = await ctrl.createSeoGapAnalysisJob({ data: validBody });
+      expect(res.status).to.equal(500);
+    });
+
+    it('returns 400 when body is missing', async () => {
+      const res = await controller.createSeoGapAnalysisJob({ data: null });
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when keyword is missing', async () => {
+      const res = await controller.createSeoGapAnalysisJob({ data: { targetUrl: TARGET } });
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when targetUrl is invalid', async () => {
+      const res = await controller.createSeoGapAnalysisJob({
+        data: { keyword: 'x', targetUrl: 'not-a-url' },
+      });
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when filterDomains is not a valid list', async () => {
+      const res = await controller.createSeoGapAnalysisJob({
+        data: { keyword: 'x', targetUrl: TARGET, filterDomains: ['https://bad.com/x'] },
+      });
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 400 when filterDomains exceeds the cap', async () => {
+      const res = await controller.createSeoGapAnalysisJob({
+        data: { keyword: 'x', targetUrl: TARGET, filterDomains: Array(51).fill('a.com') },
+      });
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 202 and enqueues the job for a valid request', async () => {
+      const res = await controller.createSeoGapAnalysisJob({ data: validBody });
+      expect(res.status).to.equal(202);
+      const body = await res.json();
+      expect(body.jobId).to.equal(JOB_ID);
+      expect(body.pollUrl).to.contain(`/seo-gap-analysis/jobs/${JOB_ID}`);
+      expect(mockSqs.sendMessage).to.have.been.calledOnce;
+      const msg = mockSqs.sendMessage.firstCall.args[1];
+      expect(msg.type).to.equal('seo-gap-analysis');
+      expect(msg.keyword).to.equal('running shoes');
+    });
+
+    it('accepts a request without optional fields (dev pollUrl)', async () => {
+      const ctrl = SeoGapAnalysisController(
+        { dataAccess: mockDataAccess, sqs: mockSqs },
+        log,
+        { AUDIT_JOBS_QUEUE_URL: 'q', AWS_ENV: 'dev' },
+      );
+      const res = await ctrl.createSeoGapAnalysisJob({
+        data: { keyword: 'x', targetUrl: TARGET },
+      });
+      expect(res.status).to.equal(202);
+      const body = await res.json();
+      expect(body.pollUrl).to.contain('/api/ci/');
+    });
+
+    it('removes the orphan job and returns 500 when SQS fails', async () => {
+      mockSqs.sendMessage.rejects(new Error('sqs down'));
+      const res = await controller.createSeoGapAnalysisJob({ data: validBody });
+      expect(res.status).to.equal(500);
+      expect(mockJob.remove).to.have.been.calledOnce;
+    });
+
+    it('logs but does not throw when orphan removal also fails', async () => {
+      mockSqs.sendMessage.rejects(new Error('sqs down'));
+      mockJob.remove.rejects(new Error('remove failed'));
+      const res = await controller.createSeoGapAnalysisJob({ data: validBody });
+      expect(res.status).to.equal(500);
+      mockJob.remove.resolves();
+    });
+
+    it('returns 500 when job creation throws', async () => {
+      mockDataAccess.AsyncJob.create.rejects(new Error('db down'));
+      const res = await controller.createSeoGapAnalysisJob({ data: validBody });
+      expect(res.status).to.equal(500);
+    });
+  });
+
+  describe('getSeoGapAnalysisJobStatus', () => {
+    it('returns 400 for an invalid jobId', async () => {
+      const res = await controller.getSeoGapAnalysisJobStatus({ params: { jobId: 'nope' } });
+      expect(res.status).to.equal(400);
+    });
+
+    it('returns 404 when the job is of a different type', async () => {
+      mockJob.getMetadata.returns({ jobType: 'site-detection' });
+      const res = await controller.getSeoGapAnalysisJobStatus({ params: { jobId: JOB_ID } });
+      expect(res.status).to.equal(404);
+    });
+
+    it('returns 200 with the report result', async () => {
+      mockJob.getResult.returns({ summary: { gapsFound: 3 } });
+      const res = await controller.getSeoGapAnalysisJobStatus({ params: { jobId: JOB_ID } });
+      expect(res.status).to.equal(200);
+      const body = await res.json();
+      expect(body.jobId).to.equal(JOB_ID);
+      expect(body.result.summary.gapsFound).to.equal(3);
+    });
+
+    it('surfaces a job error object', async () => {
+      mockJob.getError.returns({ code: 'EXCEPTION', message: 'boom' });
+      const res = await controller.getSeoGapAnalysisJobStatus({ params: { jobId: JOB_ID } });
+      const body = await res.json();
+      expect(body.error.code).to.equal('EXCEPTION');
+    });
+
+    it('returns 500 when the lookup throws', async () => {
+      mockDataAccess.AsyncJob.findById.rejects(new Error('db boom'));
+      const res = await controller.getSeoGapAnalysisJobStatus({ params: { jobId: JOB_ID } });
+      expect(res.status).to.equal(500);
+    });
+  });
+});

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -502,6 +502,11 @@ describe('getRouteHandlers', () => {
     getSiteDetectionJobStatus: sinon.stub(),
   };
 
+  const mockSeoGapAnalysisController = {
+    createSeoGapAnalysisJob: sinon.stub(),
+    getSeoGapAnalysisJobStatus: sinon.stub(),
+  };
+
   const mockPlgOnboardingController = {
     onboard: sinon.stub(),
     getAllOnboardings: sinon.stub(),
@@ -732,6 +737,7 @@ describe('getRouteHandlers', () => {
       mockEphemeralRunController,
       mockAutofixChecksController,
       mockSiteDetectionController,
+      mockSeoGapAnalysisController,
       mockPlgOnboardingController,
       mockDrsBpPgAuditController,
       mockWebhooksController,
@@ -766,6 +772,7 @@ describe('getRouteHandlers', () => {
       'GET /projects',
       'POST /projects',
       'POST /preflight/jobs',
+      'POST /seo-gap-analysis',
       'POST /sites/detect/jobs',
       'GET /sites',
       'POST /sites',
@@ -1119,6 +1126,7 @@ describe('getRouteHandlers', () => {
       'GET /projects/:projectId/sites',
       'GET /projects/by-project-name/:projectName/sites',
       'GET /preflight/jobs/:jobId',
+      'GET /seo-gap-analysis/jobs/:jobId',
       'GET /sites/detect/jobs/:jobId',
       'GET /sites/:siteId',
       'GET /sites/:siteId/identity',


### PR DESCRIPTION
Adds the public async HTTP surface for the SEO/GEO/AEO competitor gap analysis feature:

- POST /seo-gap-analysis: validates { keyword, targetUrl, filterDomains?, currentRanking?, locale? }, creates an AsyncJob (jobType seo-gap-analysis), enqueues a message on AUDIT_JOBS_QUEUE_URL for the audit worker, and returns 202 + { jobId, pollUrl }. Modeled on the site-detection async controller.
- GET /seo-gap-analysis/jobs/:jobId: returns status + gap report, scoped to the seo-gap-analysis jobType via loadJobScopedToCaller (IDOR-safe).
- Route wiring in routes/index.js + controller instantiation in index.js.
- IMS + entitlement enforced declaratively: classified in required-capabilities (site:write / site:read) and facs-capabilities (llmo + aso, can_configure / can_view). jobId already lives in FACS_NON_RESOURCE_PARAMS.
- OpenAPI: docs/openapi/seo-gap-analysis-api.yaml + registration in api.yaml.
- Unit tests: 100% coverage on the controller (20 tests); all 3585 route drift tests pass with the new entries.

Companion branches of the same name in spacecat-audit-worker (SERP + scrape + diff handlers) and spacecat-content-scraper (seo-comparison scrape handler). Follow-up: integration tests under test/it/ (Docker/postgres seed harness).

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description. Or if there's no issue created, make sure you 
  describe here the problem you're solving.
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

If the PR is changing the API specification:
- [ ] make sure you add a "Not implemented yet" note the endpoint description, if the implementation is not ready 
  yet. Ideally, return a 501 status code with a message explaining the feature is not implemented yet.
- [ ] make sure you add at least one example of the request and response.

If the PR is changing the API implementation or an entity exposed through the API:
- [ ] make sure you update the API specification and the examples to reflect the changes.

If the PR is introducing a new audit type:
- [ ] make sure you update the API specification with the type, schema of the audit result and an example

## Related Issues


Thanks for contributing!
