### PR TITLE
feat(agentic-traffic): multi-select platform list on agentic endpoints | LLMO-7553

### DIFF
--- a/src/controllers/llmo/llmo-agentic-traffic.js
+++ b/src/controllers/llmo/llmo-agentic-traffic.js
@@ -77,6 +77,37 @@ const PLATFORM_CODE_TO_DB = {
   amazon: 'Amazon',
 };
 
+// A comma in the `platform` param signals a multi-select (Serenity). Returns the
+// trimmed non-empty tokens, or null when the value is a single value / absent —
+// which keeps the single-platform path byte-identical to before.
+function splitPlatformList(raw) {
+  if (typeof raw !== 'string' || !raw.includes(',')) {
+    return null;
+  }
+  return raw.split(',').map((t) => t.trim()).filter(Boolean);
+}
+
+// Resolves the `platform` param into exactly one of two shapes:
+//   single  → { platform: <db value|null>, platforms: null }   (unchanged, fail-open)
+//   multi   → { platform: null, platforms: <db values[]|null> } (comma list; 'all' → no filter)
+// Unknown codes are silently dropped (matches the project-wide whitelist-filter
+// convention: `platform`/`successRate` silent-drop rather than 400 — see #2290). A
+// fully-unknown list therefore collapses to null (all platforms), same as a single
+// unknown value. The scalar and array RPC params AND-intersect, so a multi selection
+// nulls the scalar to avoid narrowing.
+function parsePlatforms(raw) {
+  const tokens = splitPlatformList(raw);
+  if (!tokens) {
+    return { platform: PLATFORM_CODE_TO_DB[raw] ?? null, platforms: null };
+  }
+  // An explicit 'all' anywhere in the list means "no platform filter".
+  if (tokens.includes('all')) {
+    return { platform: null, platforms: null };
+  }
+  const mapped = [...new Set(tokens.map((t) => PLATFORM_CODE_TO_DB[t]).filter(Boolean))];
+  return { platform: null, platforms: mapped.length ? mapped : null };
+}
+
 // Re-exported for existing imports.
 export { parseAgentTypes };
 
@@ -113,10 +144,13 @@ function sanitizeDateString(value, fallback) {
 function parseAgenticTrafficParams(context) {
   const q = context.data || {};
   const defaults = defaultDateRange();
+  const { platform, platforms } = parsePlatforms(q.platform);
   return {
     startDate: sanitizeDateString(q.startDate || q.start_date, defaults.startDate),
     endDate: sanitizeDateString(q.endDate || q.end_date, defaults.endDate),
-    platform: PLATFORM_CODE_TO_DB[q.platform] ?? null,
+    platform,
+    // Additive multi-select inclusion list (Serenity). null → single/absent.
+    platforms,
     categoryName: sanitizeFilterString(q.categoryName || q.category_name),
     agentType: sanitizeFilterString(q.agentType || q.agent_type),
     // Additive inclusion list, orthogonal to single-value `agentType`. Used by URL Inspector.
@@ -132,7 +166,7 @@ function parseAgenticTrafficParams(context) {
 }
 
 function buildRpcParams(siteId, parsed) {
-  return {
+  const params = {
     p_site_id: siteId,
     p_start_date: parsed.startDate,
     p_end_date: parsed.endDate,
@@ -143,6 +177,12 @@ function buildRpcParams(siteId, parsed) {
     p_content_type: parsed.contentType,
     p_success_rate: parsed.successRate,
   };
+  // Only attach the array param for a multi-select, so single-platform requests
+  // stay byte-identical (and keep working against the pre-migration RPC signature).
+  if (parsed.platforms) {
+    params.p_platforms = parsed.platforms;
+  }
+  return params;
 }
 
 function canonicalizeExportPayload(siteId, parsed) {
@@ -155,6 +195,7 @@ function canonicalizeExportPayload(siteId, parsed) {
     startDate: parsed.startDate,
     endDate: parsed.endDate,
     platform: parsed.platform,
+    platforms: parsed.platforms,
     categoryName: parsed.categoryName,
     agentType: parsed.agentType,
     userAgent: parsed.userAgent,
@@ -1217,6 +1258,11 @@ export function createAgenticTrafficUrlBrandPresenceHandler(getSiteAndValidateAc
           p_model: parsed.platform || null,
           p_site_id: siteId,
         };
+        // Multi-select drill-down: pass the model inclusion list; keep p_model null
+        // (they AND-intersect). Only attached for multi so single stays byte-identical.
+        if (parsed.platforms) {
+          rpcParams.p_models = parsed.platforms;
+        }
 
         const { data, error } = await client.rpc(
           'rpc_brand_presence_url_detail',

--- a/test/controllers/llmo/llmo-agentic-traffic.test.js
+++ b/test/controllers/llmo/llmo-agentic-traffic.test.js
@@ -309,6 +309,60 @@ describe('llmo-agentic-traffic', () => {
         });
       });
     });
+
+    it('omits p_platforms entirely for a single platform (byte-identical path)', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_kpis: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', platform: 'chatgpt' } });
+      await createAgenticTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      const params = client.rpc.getCall(0).args[1];
+      expect(params.p_platform).to.equal('ChatGPT');
+      expect(params).to.not.have.property('p_platforms');
+    });
+  });
+
+  describe('platform multi-select (Serenity)', () => {
+    it('maps a comma list to p_platforms and nulls the scalar p_platform', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_kpis: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', platform: 'chatgpt,gemini' } });
+      await createAgenticTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      expect(client.rpc).to.have.been.calledWithMatch('rpc_agentic_traffic_kpis', {
+        p_platform: null,
+        p_platforms: ['ChatGPT', 'Gemini'],
+      });
+    });
+
+    it('dedupes codes that map to the same DB value', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_kpis: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', platform: 'chatgpt,openai' } });
+      await createAgenticTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      expect(client.rpc.getCall(0).args[1].p_platforms).to.deep.equal(['ChatGPT']);
+    });
+
+    it("treats 'all' within a list as no platform filter", async () => {
+      const client = createMockClient({ rpc_agentic_traffic_kpis: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', platform: 'all,chatgpt' } });
+      await createAgenticTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      const params = client.rpc.getCall(0).args[1];
+      expect(params.p_platform).to.equal(null);
+      expect(params).to.not.have.property('p_platforms');
+    });
+
+    it('silently drops an unknown platform in a multi list, keeping the valid subset', async () => {
+      // Matches the project-wide whitelist-filter convention (silent-drop, not 400).
+      const client = createMockClient({ rpc_agentic_traffic_kpis: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', platform: 'chatgpt,bogus' } });
+      await createAgenticTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      expect(client.rpc.getCall(0).args[1].p_platforms).to.deep.equal(['ChatGPT']);
+    });
+
+    it('drops a fully-unknown multi list to no platform filter (all platforms)', async () => {
+      const client = createMockClient({ rpc_agentic_traffic_kpis: { data: [], error: null } });
+      const ctx = makeContext({ client, data: { startDate: '2026-01-01', endDate: '2026-01-28', platform: 'bogus,nope' } });
+      await createAgenticTrafficKpisHandler(stubbedValidateAccess)(ctx);
+      const params = client.rpc.getCall(0).args[1];
+      expect(params.p_platform).to.equal(null);
+      expect(params).to.not.have.property('p_platforms');
+    });
   });
 
   // ── KPIs ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

API layer of a 3-repo feature: a Serenity-gated multi-select **Platform** filter on the Agentic Traffic dashboard.

- `parsePlatforms` turns a comma-separated `platform` value into **`p_platforms`** (a single value is unchanged and **byte-identical** — no comma → scalar path). A multi selection nulls the scalar `p_platform` to avoid the AND-intersect, and `p_platforms` is attached **only** for multi (so single-platform requests keep working against the pre-migration RPC).
- `url-brand-presence` forwards **`p_models`** for the drill-down.
- Unknown codes in a list are **silently dropped** (matching the project-wide whitelist-filter convention — `platform`/`successRate` silent-drop rather than 400, per prior decision on #2290).
- Export canonical payload carries `platforms` for a distinct export hash.

Depends on **adobe/mysticat-data-service#1052** (RPC signatures) — deploy that first. UI PR (project-elmo-ui) lands last. Cross-links in a follow-up comment.

## Testing the PR changes

- `npm run lint` clean; unit tests `test/controllers/llmo/llmo-agentic-traffic.test.js` → **157 passing** (added: multi→`p_platforms`+null scalar, dedupe, `all`-in-list → no filter, single omits `p_platforms`, unknown silently dropped, fully-unknown → all).
- **Pre-merge follow-ups:** integration tests under `test/it/` for the multi-select path (needs #1052 migration in the IT harness DB); update `docs/openapi/` to document the comma-list `platform` semantics.

## Screenshots/Videos

_N/A (API)_

## Related Issue

https://jira.corp.adobe.com/browse/LLMO-7553

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
scope: multi-repo
relatedPRs: ["adobe/mysticat-data-service#1052", "adobe/spacecat-api-service#3265", "adobe/project-elmo-ui#3158"]
rationale: "Additive, backward-compatible multi-select platform filter for the Agentic Traffic dashboard across DB RPCs, API, and UI. Serenity-gated and reversible; single-platform behavior is byte-identical. Cross-repo deploy order: data-service #1052 -> api-service #3265 -> elmo #3158 (UI last; a UI-first deploy fail-opens to all platforms, which is benign)."
recommendations: "Enable the UI last, after the backend is deployed. Before merge: add integration tests (api-service test/it, data-service tests/api) and OpenAPI/schema-doc updates."
backout: "Redeploy the previous api-service release. Single-platform requests never send p_platforms; the multi path requires data-service >= v5.129.1 (agentic p_platforms RPCs, live in prod) — do not roll data-service below v5.129.0."
```


