### PR TITLE
fix(llmo): hand off Semrush provisioning for Slack-onboarded Serenity brands (LLMO-7369)

### DIFF
--- a/src/controllers/brands.js
+++ b/src/controllers/brands.js
@@ -3063,7 +3063,38 @@ function BrandsController(ctx, log, env) {
     }
   };
 
+  /**
+   * LLMO-7369 — GET /v2/orgs/:spaceCatId/brands/:brandId/resume
+   *
+   * Backend-owned, anonymous (clicked from a Slack message, which carries no IMS
+   * auth) fixed-destination redirect to the authenticated elmo-ui brand-approval
+   * flow, where a signed-in Serenity user completes Semrush provisioning as
+   * themselves via POST /serenity/activate.
+   *
+   * Deliberately side-effect-free and non-leaking: it does NOT read the brand
+   * (so it reveals nothing about whether the brand exists), never reflects any
+   * caller-supplied query/content into the destination (no open-redirect),
+   * validates the ids, and is idempotent (safe to click before or after
+   * provisioning). All real authorization happens at the elmo-ui + /serenity/
+   * activate step. The elmo-ui route contract lives ONLY here (one place),
+   * keyed off the configured base — Slack never encodes a UI URL.
+   */
+  const resumeBrandProvisioning = async (context) => {
+    const { spaceCatId, brandId } = context.params || {};
+    if (!isValidUUID(spaceCatId) || !isValidUUID(brandId)) {
+      return badRequest('Invalid organization or brand id.');
+    }
+    // Destination built purely from a configured base + validated ids — never
+    // from request-supplied content. Set LLMO_UI_BASE_URL to the elmo-ui app base
+    // for the environment (falls back to EXPERIENCE_URL).
+    const base = (env.LLMO_UI_BASE_URL || env.EXPERIENCE_URL || 'https://experience.adobe.com')
+      .replace(/\/$/, '');
+    const destination = `${base}/org/${spaceCatId}/brands-management`;
+    return createResponse('', 302, { location: destination });
+  };
+
   return {
+    resumeBrandProvisioning,
     getBrandsForOrganization,
     getBrandGuidelinesForSite,
     getBrandForOrg,

--- a/src/controllers/llmo/llmo-onboarding.js
+++ b/src/controllers/llmo/llmo-onboarding.js
@@ -39,6 +39,7 @@ import {
 import { upsertFeatureFlag } from '../../support/feature-flags-storage.js';
 import { detectCdnForDomain } from '../../support/cdn-detection.js';
 import { upsertBrand } from '../../support/brands-storage.js';
+import { isSerenityActiveForOrg } from '../../support/serenity/serenity-active.js';
 import { assertSiteOrgReassignmentSafe } from '../../support/site-org-reassignment.js';
 import {
   PROMPT_SUGGESTION_PIPELINES,
@@ -1409,6 +1410,11 @@ export async function activateBrandAndGeneratePrompts({
   let promptGenerationError = null;
   let promptSuggestionSchedules = null;
   let promptSuggestionSchedulesTimedOut = false;
+  // LLMO-7369: signals for the Slack/HTTP caller so it can distinguish a fully
+  // onboarded brand from a Serenity brand that still needs IMS-authenticated
+  // Semrush provisioning (and build the authenticated resume hand-off).
+  let semrushProvisioningPending = false;
+  let provisionedBrandId = null;
 
   if (onboardingMode === LLMO_ONBOARDING_MODE_V2) {
     const postgrestClient = context.dataAccess?.services?.postgrestClient;
@@ -1427,7 +1433,7 @@ export async function activateBrandAndGeneratePrompts({
     try {
       const { data: existingBrand, error: lookupError } = await postgrestClient
         .from('brands')
-        .select('id, site_id')
+        .select('id, site_id, status')
         .eq('organization_id', organization.getId())
         .eq('name', brandName.trim())
         .maybeSingle();
@@ -1452,11 +1458,22 @@ export async function activateBrandAndGeneratePrompts({
         // DEFAULT_BRAND_REGION placeholder (consistent with the V2 config +
         // brandAliases, both overwritten by Brandalf's async result).
         const stubRegions = onboardingStubRegions(region);
-        await upsertBrand({
+        // LLMO-7369: for a Serenity-active org the Semrush sub-workspace/project
+        // cannot be provisioned from this context (Slack/webhook carries no IMS
+        // identity), so a NET-NEW (or not-yet-active) brand must NOT be presented
+        // as a complete active brand. Persist it as `pending` — a durable,
+        // resumable, reconcilable "awaiting IMS provisioning" record that a
+        // Serenity human completes via the authenticated /serenity/activate path.
+        // An already-active brand is left active (never demoted here — that would
+        // hit the demotion guard; the reconcile path repairs stuck actives).
+        // Non-Serenity orgs keep the historical `active` write (no Semrush).
+        const serenityActive = await isSerenityActiveForOrg(context, organization.getId(), log);
+        const brandStatus = (serenityActive && existingBrand?.status !== 'active') ? 'pending' : 'active';
+        const upserted = await upsertBrand({
           organizationId: organization.getId(),
           brand: {
             name: brandName.trim(),
-            status: 'active',
+            status: brandStatus,
             baseSiteId: site.getId(),
             region: stubRegions,
             urls: [{ value: baseURL, type: 'base' }],
@@ -1466,7 +1483,10 @@ export async function activateBrandAndGeneratePrompts({
           updatedBy: 'llmo-onboarding',
           log,
         });
+        provisionedBrandId = upserted?.id ?? existingBrand?.id ?? null;
+        semrushProvisioningPending = brandStatus === 'pending';
         log.info(`Created initial brand "${brandName}" in normalized table for site ${site.getId()}`);
+        log.info(`Initial brand "${brandName}" status=${brandStatus} (semrushProvisioningPending=${semrushProvisioningPending})`);
       }
     } catch (brandError) {
       log.warn(`Failed to create initial brand in normalized table: ${brandError.message}`);
@@ -1654,6 +1674,9 @@ export async function activateBrandAndGeneratePrompts({
     promptSuggestionSchedules,
     promptSuggestionSchedulesTimedOut,
     requiredWorkFailed,
+    // LLMO-7369
+    semrushProvisioningPending,
+    brandId: provisionedBrandId,
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -503,7 +503,7 @@ const wrappedMain = wrap(run)
     // `anonymousEndpoints` is picked up. Declaring it now is forward-safe, not a behaviour
     // change: the option replaces only the exact-match route list -- the unconditional OPTIONS
     // and `POST /hooks/site-detection/*` bypasses are separate clauses it does not touch.
-    anonymousEndpoints: ['POST /slack/events'],
+    anonymousEndpoints: ['POST /slack/events', 'GET /v2/orgs/:spaceCatId/brands/:brandId/resume'],
   })
   .with(s2sAuthWrapper, { routeCapabilities: routeRequiredCapabilities });
 

--- a/src/routes/facs-capabilities.js
+++ b/src/routes/facs-capabilities.js
@@ -197,6 +197,7 @@ const routeFacsCapabilities = {
     'POST /hooks/site-detection/rum/:hookSecret', // hookSecret in path
     'POST /webhooks/github', // HMAC-signed webhook
     'POST /slack/events', // Slack signature verification (slackSignatureWrapper)
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/resume', // LLMO-7369 anonymous backend-owned redirect (no FACS)
     'POST /slack/channels/invite-by-user-id', // Slack-internal
     'GET /trigger', // internal scheduler
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -240,6 +240,9 @@ export default function getRouteHandlers(
     'PATCH /v2/orgs/:spaceCatId/brands/:brandId/status': brandsController.transitionBrandStatusForOrg,
     'DELETE /v2/orgs/:spaceCatId/brands/:brandId': brandsController.deleteBrandForOrg,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/activate': brandsController.activateBrandForOrg,
+    // LLMO-7369: anonymous backend-owned hand-off (see anonymousEndpoints in index.js).
+    // Redirects a Slack-clicked link to the authenticated elmo-ui brand-approval flow.
+    'GET /v2/orgs/:spaceCatId/brands/:brandId/resume': brandsController.resumeBrandProvisioning,
     'GET /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': serenityController.listPrompts,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts': serenityController.createPrompts,
     'POST /v2/orgs/:spaceCatId/brands/:brandId/serenity/prompts/bulk-tags': serenityController.bulkTagPrompts,

--- a/src/support/slack/actions/onboard-llmo-modal.js
+++ b/src/support/slack/actions/onboard-llmo-modal.js
@@ -457,17 +457,44 @@ export async function onboardSite(input, lambdaCtx, slackCtx) {
     // already streamed to this thread in real time as they happened; this final banner must
     // not override that with an unconditional checkmark when required work actually failed.
     const requiredWorkFailed = result.brandActivation?.requiredWorkFailed ?? false;
+    // LLMO-7369: for a Serenity-active org the brand was created `pending` because
+    // Semrush provisioning needs an IMS identity this context does not have.
+    const semrushPending = result.brandActivation?.semrushProvisioningPending ?? false;
+    const pendingBrandId = result.brandActivation?.brandId ?? null;
+    const spaceCatOrgId = site.getOrganizationId?.();
+    // Backend-owned authenticated resume hand-off: link to the spacecat resume
+    // endpoint (which 302s to the elmo-ui brand-approval flow) so no elmo-ui URL
+    // contract is hardcoded in Slack.
+    const apiBase = env.SPACECAT_API_BASE_URL;
+    const resumeLink = (semrushPending && pendingBrandId && spaceCatOrgId && apiBase)
+      ? `${apiBase.replace(/\/$/, '')}/v2/orgs/${spaceCatOrgId}/brands/${pendingBrandId}/resume`
+      : null;
     const regionLine = region ? `\n:globe_with_meridians: *Region:* ${region}` : '';
-    const statusLine = requiredWorkFailed
-      ? ':warning: *LLMO onboarding completed with warnings* — see the messages above for what needs manual follow-up.'
-      : ':white_check_mark: *LLMO onboarding completed successfully!*';
+    let statusLine;
+    if (requiredWorkFailed) {
+      statusLine = ':warning: *LLMO onboarding completed with warnings* — see the messages above for what needs manual follow-up.';
+    } else if (semrushPending) {
+      // LLMO-7369 AC3: must not claim Semrush-backed onboarding is complete when it is not.
+      statusLine = ':hourglass_flowing_sand: *Brandalf/DRS onboarding submitted — Semrush provisioning still required.*';
+    } else {
+      statusLine = ':white_check_mark: *LLMO onboarding completed successfully!*';
+    }
+    // LLMO-7369 AC3/AC4: tell the operator Semrush is not yet provisioned and hand
+    // off to the authenticated UI to complete it as themselves.
+    const semrushBlock = semrushPending
+      ? `\n\n:hourglass_flowing_sand: *Semrush provisioning is pending* — this brand is *not yet usable* in Brand Visibility (no Semrush sub-workspace/project yet), because the Slack context has no IMS identity to provision one.${
+        resumeLink
+          ? `\n:arrow_right: *Complete provisioning (sign-in required):* ${resumeLink}\nOpen the link while signed in, then *Approve* the pending brand to provision Semrush as yourself.`
+          : '\n:arrow_right: Complete provisioning from the authenticated Brands UI: open Brand Visibility while signed in and *Approve* the pending brand.'
+      }`
+      : '';
     const message = `${statusLine}
 
 :link: *Site:* ${baseURL}
 :identification_card: *Site ID:* ${siteId}
 :file_folder: *Data Folder:* ${dataFolder}
 :label: *Brand:* ${brandName}
-:identification_card: *IMS Org ID:* ${imsOrgId}${regionLine}
+:identification_card: *IMS Org ID:* ${imsOrgId}${regionLine}${semrushBlock}
 
 The LLMO Customer Analysis handler has been triggered. It will take a few minutes to complete.`;
 

--- a/test/controllers/brands.test.js
+++ b/test/controllers/brands.test.js
@@ -200,6 +200,57 @@ describe('Brands Controller', () => {
     expect(() => BrandsController(context, loggerStub)).to.throw('Environment object required');
   });
 
+  describe('resumeBrandProvisioning (LLMO-7369)', () => {
+    const validOrg = '0d1fbce6-8b4e-4e01-9e28-2365d38ab78d';
+    const validBrand = '01a06c3a-38b6-76ba-afd1-6a09d89b2bad';
+
+    it('302-redirects to the elmo-ui brand-approval flow (default base) without reading the brand', async () => {
+      // No brand is mocked — a 302 regardless proves the redirect is dumb and
+      // non-leaking (it never checks whether the brand exists).
+      const response = await brandsController.resumeBrandProvisioning({
+        params: { spaceCatId: validOrg, brandId: validBrand },
+      });
+      expect(response.status).to.equal(302);
+      expect(response.headers.get('location')).to.equal(
+        `https://experience.adobe.com/org/${validOrg}/brands-management`,
+      );
+    });
+
+    it('uses LLMO_UI_BASE_URL when configured (trailing slash trimmed)', async () => {
+      const ctrl = BrandsController(context, loggerStub, { ...mockEnv, LLMO_UI_BASE_URL: 'https://ui.example.com/' });
+      const response = await ctrl.resumeBrandProvisioning({
+        params: { spaceCatId: validOrg, brandId: validBrand },
+      });
+      expect(response.status).to.equal(302);
+      expect(response.headers.get('location')).to.equal(
+        `https://ui.example.com/org/${validOrg}/brands-management`,
+      );
+    });
+
+    it('never reflects caller-supplied content into the destination (no open redirect)', async () => {
+      const response = await brandsController.resumeBrandProvisioning({
+        params: { spaceCatId: validOrg, brandId: validBrand },
+        // A hostile query string must not influence the Location.
+        pathInfo: { headers: {} },
+        data: { next: 'https://evil.example.com' },
+      });
+      expect(response.headers.get('location')).to.equal(
+        `https://experience.adobe.com/org/${validOrg}/brands-management`,
+      );
+    });
+
+    it('returns 400 for an invalid organization or brand id', async () => {
+      const bad1 = await brandsController.resumeBrandProvisioning({
+        params: { spaceCatId: 'not-a-uuid', brandId: validBrand },
+      });
+      expect(bad1.status).to.equal(400);
+      const bad2 = await brandsController.resumeBrandProvisioning({
+        params: { spaceCatId: validOrg, brandId: 'not-a-uuid' },
+      });
+      expect(bad2.status).to.equal(400);
+    });
+  });
+
   describe('getBrandsForOrganization', () => {
     it('returns brands for a valid organization', async () => {
       const mockBrands = [{ id: 'brand1' }, { id: 'brand2' }];

--- a/test/controllers/llmo/llmo-onboarding.test.js
+++ b/test/controllers/llmo/llmo-onboarding.test.js
@@ -306,6 +306,12 @@ describe('LLMO Onboarding Functions', () => {
     deps['../../../src/support/brands-storage.js'] = {
       upsertBrand: options.mockUpsertBrand || sinon.stub().resolves({ id: 'brand-123', name: 'Test Brand' }),
     };
+    // LLMO-7369: default to non-Serenity (brand created `active`, historical
+    // behavior). Override via options.mockIsSerenityActiveForOrg to exercise the
+    // Serenity `pending` (awaiting-provisioning) path.
+    deps['../../../src/support/serenity/serenity-active.js'] = {
+      isSerenityActiveForOrg: options.mockIsSerenityActiveForOrg || sinon.stub().resolves(false),
+    };
 
     deps['../../../src/support/cdn-detection.js'] = {
       detectCdnForDomain: options.mockDetectCdnForDomain || sinon.stub().resolves(null),
@@ -6581,6 +6587,45 @@ describe('LLMO Onboarding Functions', () => {
       expect(errorLog).to.include('status=503');
       // Onboarding still completed (Brandalf fired, resolve did not throw).
       expect(instance.submitJob).to.have.been.calledOnce;
+    });
+
+    it('LLMO-7369: creates the brand as pending for a Serenity-active org and signals provisioning pending', async () => {
+      const mockUpsertBrand = sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
+      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockDrsClient: createMockDrsClient(sandbox),
+          mockUpsertBrand,
+          mockIsSerenityActiveForOrg: sandbox.stub().resolves(true),
+        }),
+      );
+
+      const context = buildV2Context();
+      const result = await activateBrandAndGeneratePrompts(buildV2Params(context));
+
+      // Brand persisted as `pending` (awaiting IMS provisioning), never a
+      // misleading complete `active` brand with no Semrush sub-workspace.
+      expect(mockUpsertBrand).to.have.been.calledOnce;
+      expect(mockUpsertBrand.firstCall.args[0].brand).to.include({ status: 'pending' });
+      // Signals for the Slack authenticated hand-off.
+      expect(result.semrushProvisioningPending).to.equal(true);
+      expect(result.brandId).to.equal('brand-123');
+    });
+
+    it('LLMO-7369: creates the brand as active (no provisioning-pending) for a non-Serenity org', async () => {
+      const mockUpsertBrand = sandbox.stub().resolves({ id: 'brand-123', name: 'Test Brand' });
+      const { activateBrandAndGeneratePrompts } = await esmockOnboarding(
+        createCommonEsmockDependencies({
+          mockDrsClient: createMockDrsClient(sandbox),
+          mockUpsertBrand,
+          mockIsSerenityActiveForOrg: sandbox.stub().resolves(false),
+        }),
+      );
+
+      const context = buildV2Context();
+      const result = await activateBrandAndGeneratePrompts(buildV2Params(context));
+
+      expect(mockUpsertBrand.firstCall.args[0].brand).to.include({ status: 'active' });
+      expect(result.semrushProvisioningPending).to.equal(false);
     });
 
     it('does not abort onboarding when DrsClient.createFrom throws (best-effort contract)', async () => {

--- a/test/routes/index.test.js
+++ b/test/routes/index.test.js
@@ -998,6 +998,7 @@ describe('getRouteHandlers', () => {
       'PATCH /v2/orgs/:spaceCatId/brands/:brandId/status',
       'DELETE /v2/orgs/:spaceCatId/brands/:brandId',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/activate',
+      'GET /v2/orgs/:spaceCatId/brands/:brandId/resume',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts',
       'GET /v2/orgs/:spaceCatId/brands/:brandId/prompts/stats',
       'POST /v2/orgs/:spaceCatId/brands/:brandId/prompts',

--- a/test/support/slack/actions/onboard-llmo-modal.test.js
+++ b/test/support/slack/actions/onboard-llmo-modal.test.js
@@ -510,6 +510,60 @@ describe('onboard-llmo-modal', () => {
       expect(triggerBrandProfileAgentStub).to.have.been.calledOnce;
     });
 
+    it('LLMO-7369: posts the Semrush-pending hand-off (not a success banner) with a resume link for a Serenity org', async () => {
+      const mockSite = createDefaultMockSite(sandbox);
+      const lambdaCtx = createDefaultMockLambdaCtx(sandbox, { mockSite });
+      lambdaCtx.env.SPACECAT_API_BASE_URL = 'https://api.example.com';
+      const slackCtx = createDefaultMockSlackCtx(sandbox);
+      const sayStub = slackCtx.say;
+
+      const performLlmoOnboardingStub = sandbox.stub().resolves({
+        site: mockSite,
+        siteId: 'site123',
+        organizationId: 'org123',
+        baseURL: 'https://example.com',
+        dataFolder: 'example-com',
+        message: 'LLMO onboarding completed successfully',
+        brandActivation: {
+          requiredWorkFailed: false,
+          semrushProvisioningPending: true,
+          brandId: 'brand-123',
+        },
+      });
+
+      const modalPending = await esmock('../../../../src/support/slack/actions/onboard-llmo-modal.js', {
+        '../../../../src/controllers/llmo/llmo-onboarding.js': {
+          performLlmoOnboarding: performLlmoOnboardingStub,
+          validateSiteNotOnboarded: sandbox.stub().resolves({ isValid: true }),
+          generateDataFolder: sandbox.stub().returns('example-com'),
+        },
+        '../../../../src/utils/slack/base.js': sharedSlackMock,
+        '../../../../src/support/brand-profile-trigger.js': {
+          triggerBrandProfileAgent: (...args) => triggerBrandProfileAgentStub(...args),
+        },
+      });
+
+      await modalPending.onboardSite(
+        {
+          baseURL: 'https://example.com',
+          brandName: 'Test Brand',
+          imsOrgId: 'ABC123@AdobeOrg',
+          deliveryType: 'aem_edge',
+        },
+        lambdaCtx,
+        slackCtx,
+      );
+
+      // AC3: must NOT claim complete; must show the pending hand-off variant.
+      expect(sayStub).to.not.have.been.calledWith(sinon.match(':white_check_mark: *LLMO onboarding completed successfully!*'));
+      expect(sayStub).to.have.been.calledWith(sinon.match('Semrush provisioning still required'));
+      expect(sayStub).to.have.been.calledWith(sinon.match('Semrush provisioning is pending'));
+      // AC4: backend-owned authenticated resume link.
+      expect(sayStub).to.have.been.calledWith(sinon.match(
+        'https://api.example.com/v2/orgs/org123/brands/brand-123/resume',
+      ));
+    });
+
     it('should surface region in the success message when supplied (LLMO-4683)', async () => {
       const input = {
         baseURL: 'https://example.com',


### PR DESCRIPTION
## LLMO-7369 — PR1 of 3

Slack `onboard-llmo` creates an **active** brand and reports success, but cannot provision the Semrush sub-workspace/project: `POST /slack/events` carries no IMS identity, so `resolveSemrushImsToken` fails closed. The brand is left `active` with `semrush_sub_workspace_id = null` and is **not usable** in Brand Visibility (prod examples: HEETS YELLOW, IQOS ILUMA i).

This PR re-anchors onboarding on **persisted, resumable state** and hands off completion to the authenticated UI — without ever placing a credential in the Slack webhook.

### What changed (spacecat-only)
- **Pending state** (`llmo-onboarding.js`): for **Serenity-active** orgs, a net-new brand is persisted as `pending` (awaiting IMS provisioning) instead of a misleading complete `active` brand. Non-Serenity/PLG onboarding is unchanged; an already-active brand is never demoted (repair is left to reconcile in PR2).
- **Honest Slack response** (`onboard-llmo-modal.js`): distinguishes Brandalf/DRS completion from Semrush provisioning; when pending, shows a hand-off instead of a success banner.
- **Backend-owned resume redirect** (`brands.js` + routing): new anonymous, side-effect-free, non-leaking `GET /v2/orgs/:spaceCatId/brands/:brandId/resume` → the elmo-ui brand-**Approve** flow, where a signed-in Serenity user completes provisioning as themselves via the existing `POST /serenity/activate`. Registered as an anonymous endpoint and in `INTERNAL_ROUTES` (bypasses FACS).

### ACs addressed
AC1 (detect Serenity mode), AC2 (no apparently-complete active brand w/o sub-workspace), AC3 (response distinguishes DRS vs Semrush), AC4 (authenticated UI hand-off). AC5–AC8 (idempotent provisioning + reconcile) land with PR2/PR3.

### Testing
+7 tests: pending vs active onboarding paths; resume endpoint (default base, `LLMO_UI_BASE_URL`, no-open-redirect, invalid ids); Slack pending hand-off message. Route-governance lists updated. All affected suites green; lint clean.

### Trust boundary
No credential in the Slack webhook; the IMS-only Semrush contract is preserved.

### Open items before merge
- [ ] **Brandalf writeback**: confirm the async agent does not re-promote the `pending` brand to `active` (or make it pending-aware). Contained by PR2 reconcile, but affects AC2 cleanliness.
- [ ] **Consumer audit** of the pending window: every `getBrandBySite` / `listBrandIdsForSite` caller + post-onboarding triggers (pre/post-activation decision each).
- [ ] Set **`LLMO_UI_BASE_URL`** per environment (falls back to `EXPERIENCE_URL`); confirm the exact elmo-ui route prefix.

### Follow-ups
- **PR2**: reconcile job (notify-only, credential-ready) + one-time backfill for the stuck fleet.
- **PR3** (separate, security-reviewed): Sites Internal service account for unattended / one-stop completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
